### PR TITLE
configure.ac: Don't create Makefiles for sdlnet and none.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -317,8 +317,6 @@ AC_CONFIG_FILES([
   src/input/sdl/Makefile
   src/multiplayer/Makefile
   src/multiplayer/common/Makefile
-  src/multiplayer/sdlnet/Makefile
-  src/multiplayer/none/Makefile
   src/server/Makefile
   src/video/Makefile
   src/video/common/Makefile


### PR DESCRIPTION
This fixes the following errors when generating and running configure in a fresh repository:

configure.ac:301: error: required file 'src/multiplayer/sdlnet/Makefile.in' not found
configure.ac:301: error: required file 'src/multiplayer/none/Makefile.in' not found
config.status: error: cannot find input file: `Makefile.in'
