### PR TITLE
VgaSDL: Set the window size at runtime.

### DIFF
--- a/src/video/sdl/vga_sdl.cpp
+++ b/src/video/sdl/vga_sdl.cpp
@@ -73,8 +73,27 @@ int VgaSDL::init()
    if (SDL_Init(SDL_INIT_VIDEO))
       return 0;
 
-   if (SDL_CreateWindowAndRenderer(1024,
-                                   768,
+   SDL_DisplayMode mode;
+   int window_width = 1024;
+   int window_height = 768;
+
+   if (SDL_GetDesktopDisplayMode(0, &mode) == 0)
+   {
+      if (mode.h < 1024)
+      {
+         window_width = 800;
+         window_height = 600;
+      }
+   }
+   else
+   {
+      ERR("Could not get desktop display mode: %s\n", SDL_GetError());
+      SDL_Quit();
+      return 0;
+   }
+
+   if (SDL_CreateWindowAndRenderer(window_width,
+                                   window_height,
                                    video_mode_flags,
                                    &window,
                                    &renderer) < 0)


### PR DESCRIPTION
If the height of the primary display resolution is less than 1024, the size of the window will be set to 800x600; otherwise, it will be set to 1024x768.

I did not make it an error if the resolution height is less than 600. The game creates a window first, and then changes to fullscreen mode. That means it won't be possible to play in fullscreen mode at lower resolutions if the game disallows heights < 600.
