### PR TITLE
build: Fix cross-compilation errors.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -188,7 +188,7 @@ AS_IF([test "$input_backend" = sdl \
   LIBS="$SDL_LIBS $LIBS"
 ])
 
-SEARCH_LIB_FLAGS([enet_initialize], ["-lenet -lwsock32" -lenet], [], [
+SEARCH_LIB_FLAGS([enet_initialize], ["-lenet -lws2_32 -lwinmm" -lenet], [], [
   AC_ERROR([enet not found])
 ])
 
@@ -206,7 +206,6 @@ AS_IF([test "$input_backend" = dinput], [
 
 AS_IF([test "$use_windows" = yes], [
   LIBS="-lole32 -lmsvcrt -lwinmm $LIBS"
-  LDFLAGS="-mno-cygwin $LDFLAGS"
 
   AS_IF([test "$enable_debug" = no], [
     LDFLAGS="$LDFLAGS -mwindows"

--- a/m4/openal.m4
+++ b/m4/openal.m4
@@ -29,7 +29,7 @@ AC_DEFUN([AM_PATH_OPENAL], [
   ac_cv_openal_al_libs=
   AS_IF([test -n "$ac_cv_openal_al_h" && test -n "$ac_cv_openal_alc_h"], [
     ac_save_LIBS="$LIBS"
-    AS_FOR([], [lib], ["-framework OpenAL" "-lopenal" "-lopenal32"], [
+    AS_FOR([], [lib], ["-framework OpenAL" "-lopenal" "-lopenal32" "-lOpenAL32"], [
       LIBS="$lib $ac_save_LIBS"
       AC_MSG_CHECKING([for alGenSources in $lib])
       AC_TRY_LINK([#include OPENAL_AL_H], [alGenSources (1, 0);], [


### PR DESCRIPTION
Tested with mingw-w32-bin_i686-linux_20130523. Building with wineg++ and DirectX (from Wine 1.7.6) with host g++ 4.8.2 also works.
