### PR TITLE
GameMP: Abort setup if mp_join_session() fails.

### DIFF
--- a/src/client/OGAMEMP.cpp
+++ b/src/client/OGAMEMP.cpp
@@ -648,8 +648,9 @@ void Game::multi_player_game(int lobbied, char *game_host)
 
 			if (!mp_join_session(choice, config.player_name))
 			{
-				choice = 0;
 				box.msg("Unable to connect");
+				mp_obj.deinit();
+				return;
 			}
 
 			remote.init(&mp_obj);
@@ -873,8 +874,9 @@ void Game::load_mp_game(char *fileName, int lobbied, char *game_host)
 
 			if (!mp_join_session(choice, config.player_name))
 			{
-				choice = 0;
 				box.msg("Unable to connect");
+				mp_obj.deinit();
+				return;
 			}
 
 			// count required player


### PR DESCRIPTION
mp_join_session() is ultimately responsible for setting mp_obj.host to a
valid value. If it fails, enet_host_service() will be called with a null
host, resulting in a crash. This can happen if, for example, the player
cancels the password input box when joining a game. Returning to the
main main if mp_join_session() returns 0 will ensure that we don't
continue the setup with an invalid state.

This patch conflicts with the gettext branch's OGAMEMP.cpp.
