### PR TITLE
OBUTT3D.cpp: Fix static buffer overflow.

### DIFF
--- a/src/client/OBUTT3D.cpp
+++ b/src/client/OBUTT3D.cpp
@@ -31,7 +31,7 @@
 
 //---------- define static vars ----------//
 
-static char save_back_buf[BUTTON_ACTION_WIDTH * BUTTON_ACTION_HEIGHT];
+static char save_back_buf[BUTTON_ACTION_WIDTH * BUTTON_ACTION_HEIGHT + 4];
 
 
 //-------- Begin of function Button3D::Button3D -------//


### PR DESCRIPTION
The save_back_buf array did not include enough storage for the bitmap
width and height (4 bytes), causing IMGread() to write past the end of
the array.

Found by AddressSanitizer. To reproduce the bug, start a new game and
click on your fort.
