### PR TITLE
fixes error when loading the game and encountering NULL townPtrs

### DIFF
--- a/src/client/OTOWNA.cpp
+++ b/src/client/OTOWNA.cpp
@@ -794,9 +794,14 @@ Town* TownArray::operator[](int recNo)
 {
 	Town* townPtr = (Town*) get_ptr(recNo);
 
+/* sraboy patch: Eliminates the ability for the game to attempt to save the
+/				 game before it's completed loading it. If NULL pointers are
+/				 encountered here on loading, nation_array hasn't been
+/				 initialized yet and GameFile::read_file_3() will break.
+/				 Code elsewhere should simply handle NULL pointers as needed.
 	if( !townPtr )
 		err.run( "TownArray[] is deleted" );
-
+	*/
 	return townPtr;
 }
 


### PR DESCRIPTION
As mentioned here: http://www.7kfans.com/forums/viewtopic.php?f=13&t=690&p=4692#p4692

When the game is first loading, the new TownArray::operator[]() runs before nation_array is loaded and if TownArray encounters an error and attempts to save the game, the gamesave will crash because it hasn't finished loading and there are uninitialized variables.
