### PR TITLE
moves recreate_after_load() 

### DIFF
--- a/src/client/OGFILE.cpp
+++ b/src/client/OGFILE.cpp
@@ -34,6 +34,7 @@
 #include <OWORLD.h>
 #include <OPOWER.h>
 #include <OGAME.h>
+#include <OTownNetwork.h>
 #include <OINFO.h>
 #include <OGFILE.h>
 #include <OSYS.h>
@@ -244,7 +245,18 @@ int GameFile::load_game(const char *base_path, char* fileName)
 		}
 
 		if( rc > 0 )
+		{
 			load_process();           // process game data after loading the game
+			
+			/* sraboy patch 23DEC13
+			/ Moved from TownArray::read_file() to eliminate
+			/ the possibility of saving ERROR.SAV before the
+			/ nation_array() has been loaded which causes a crash
+			*/
+			//------- create the town network --------//
+			town_network_array.recreate_after_load();
+			
+		}
 		// ###### patch end Gilbert 20/1 #######//
 	}
 

--- a/src/client/OGFILE3.cpp
+++ b/src/client/OGFILE3.cpp
@@ -38,7 +38,6 @@
 #include <OSPY.h>
 #include <OTORNADO.h>
 #include <OTOWN.h>
-#include <OTownNetwork.h>
 #include <OU_MARI.h>
 #include <dbglog.h>
 #include <file_io_visitor.h>
@@ -1221,9 +1220,13 @@ int TownArray::read_file(File* filePtr)
 
 	read_empty_room(filePtr);
 
+	/* sraboy patch 23DEC13
+	/ Moved to TownArray::read_file() to eliminate
+	/ the possibility of saving ERROR.SAV before the
+	/ nation_array() has been loaded which causes a crash
 	//------- create the town network --------//
-
 	town_network_array.recreate_after_load();
+	*/
 
 	return 1;
 }


### PR DESCRIPTION
Moves recreate_after_load() to prevent crashing while writing to ERROR.SAV with uninitialized variables. I tested it with saving a new game and being able to load it with no problems. I also verified that it loads and crashes on the old SAV file that was causing issues in the old pull request (https://github.com/the3dfxdude/7kaa/pull/18) while in DEBUG. It loads both new and old SAV files fine without DEBUG. Pull https://github.com/the3dfxdude/7kaa/pull/18 has been resubmitted as https://github.com/the3dfxdude/7kaa/pull/21 with new source comments explaining the slightly different bug.
