### PR TITLE
Town Network: Fix issue with DEBUG defined and empty town_array entries

### DIFF
--- a/src/client/OTownNetwork.cpp
+++ b/src/client/OTownNetwork.cpp
@@ -375,7 +375,7 @@ void TownNetworkArray::town_destroyed(int townRecno)
 	if (townRecno == 0) {if (DEBUG_CHECK) throw "townRecno is 0"; else return;}
 
 	Town *pTown = town_array[townRecno];
-	if (pTown == NULL) {if (DEBUG_CHECK) throw "Town is no longer exists in TownArray"; else return;}
+	if (pTown == NULL) {if (DEBUG_CHECK) throw "Town no longer exists in TownArray"; else return;}
 
 	// Independent towns do not form town networks
 	if (pTown->nation_recno == 0)
@@ -580,8 +580,8 @@ void TownNetworkArray::recreate_after_load()
 {
 	for (int i = 1; i <= town_array.size(); ++i)
 	{
+		if (town_array.is_deleted(i)) continue; // Skip over empty elements
 		Town *pTown = town_array[i];
-		if (pTown == NULL) continue; // Skip over empty elements
 		
 		// Create town networks for each town without a town network.
 		// Independent towns do not form town networks


### PR DESCRIPTION
Fix for #21, thanks to sraboy for finding this error.

Now using TownArray::is_deleted to check for null entries; this is in line with the rest of the code.

I double checked, because is_deleted also checks if population > 0, but any town whose population reaches 0 is immediately deinitialised, which means it is removed from the town_network, so this check fixes 'a double bug': 1) with NULL entries with DEBUG defined, and 2) with dying towns that were saved to file.
