### PR TITLE
Resolves bug with units pathfinding to a now dead ship

### DIFF
--- a/src/client/OUNITS.cpp
+++ b/src/client/OUNITS.cpp
@@ -252,10 +252,14 @@ void Unit::ship_to_beach(int destX, int destY, int& finalDestX, int& finalDestY)
 	err_when(terrain_res[world.get_loc(destX, destY)->terrain_id]->average_type == TERRAIN_OCEAN);
 
 	//----------------------------------------------------------------//
-	// return if the unit is dead
+	// change to move_to if the unit is dead
 	//----------------------------------------------------------------//
 	if(hit_points<=0 || action_mode==ACTION_DIE || cur_action==SPRITE_DIE)
+	{
+		move_to(destX, destY, 1);
+		finalDestX = finalDestY = -1; 
 		return;
+	}
 
 	//----------------------------------------------------------------//
 	// change to move_to if the ship cannot carry units


### PR DESCRIPTION
Re: http://www.7kfans.com/forums/viewtopic.php?f=13&t=529.

Now that the funny DEBUG loading thing is resolved with Pull 22 can we take care of this one?

If a game is saved after a ship's hit points are set to 0, but before the sprites are destroyed or set to ACTION_DIE or SPRITE_DIE, they're loaded with the game and are not resolved. The only check done by UnitArray::assign_to_ship() is to ensure the values aren't -1 before using them for assignment. The crash happens on line 1057. 

The fix is that the units simply move_to() the coast near where the ship was just like they would if the ship couldn't carry units.
