### PR TITLE
Allow Bullets to hit own spies when disguised as an enemy unit

### DIFF
--- a/src/client/OBULLET.cpp
+++ b/src/client/OBULLET.cpp
@@ -285,7 +285,7 @@ void Bullet::hit_target(short x, short y)
 	if( attackDamage == 0 )
 		return;
 
-	if( targetUnit->is_nation(nation_recno) )
+	if( targetUnit->nation_recno == nation_recno )
 	{
 		if( targetUnit->unit_id == UNIT_EXPLOSIVE_CART )
 			((UnitExpCart *)targetUnit)->trigger_explode();


### PR DESCRIPTION
Allow ranged attacks to hit your own spies when they are disguised as an enemy nation's unit.
Close-range attacks already allowed this.
