### PR TITLE
Prevent new nations from surrendering if they haven't been around for atleast 2 years.

### DIFF
--- a/include/ONATION.h
+++ b/include/ONATION.h
@@ -212,6 +212,7 @@ public:
 	//--------------------------------------------------------//
 	// parameters used to make decisions
 	//--------------------------------------------------------//
+	int				ai_create_date;
 	short			ai_town_size;
 	short			ai_base_size;
 	short			ai_mine_size;

--- a/src/client/OAI_GRAN.cpp
+++ b/src/client/OAI_GRAN.cpp
@@ -320,6 +320,10 @@ int Nation::think_surrender()
 	if( !rc )
 		return 0;
 
+	//don't surrender if nation hasn't been around for 2 years
+	if(ai_create_date + 365*2 > info.game_date)
+		return 1;
+
 	//---- see if there is any nation worth getting our surrender ---//
 
 	Nation* nationPtr;

--- a/src/client/OAI_MAIN.cpp
+++ b/src/client/OAI_MAIN.cpp
@@ -72,6 +72,8 @@ void Nation::init(int nationType, int raceId, int colorSchemeId, DWORD playerId)
 
 	attack_camp_count = 0;
 
+	ai_create_date = info.game_date;
+
 	//------ init AI info arrays -----//
 
 	init_all_ai_info();


### PR DESCRIPTION
Added a date check on AI thinking of surrender. This prevents situations where a new nation is formed and immediately surrenders to an existing nation.

Through quite a few speed plays I found that often, a new nation would form, and before even doing anything, a month in it would just surrender to another nation. Essentially voiding any reason for a new kingdom in the first place.