### PR TITLE
dbglog: Added separate macro for enabling debug log. [FIXED]

### DIFF
--- a/src/common/dbglog.cpp
+++ b/src/common/dbglog.cpp
@@ -67,7 +67,7 @@ int dbglog_init()
 		{
 			dbglog_settings[i].flags = DBGLOG_ERR_ON|DBGLOG_MSG_ON;
 		} else {
-			dbglog_settings[i].flags = DBGLOG_ERR_ON; // Receive only errors. Use DBGLOG_NEED_INIT to silence unwatched channels completely
+			dbglog_settings[i].flags = DBGLOG_NEED_INIT;
 		}
 	}
 


### PR DESCRIPTION
This fixes commit 'e8557a6a489106b7ef6 dblog: Added seperate macr...' which actually broke the debug log for all channels that were not explicitly registered via the environment variable.

I misunderstood how dbglog works, so I ended up breaking it by trying to 'add' what was already there. The old and new commit together have the effect of only adding the macro DEBUG_ENABLE_MESSAGES to enable the dbglog.
