### PR TITLE
Independent town creation

### DIFF
--- a/src/client/OTOWNA.cpp
+++ b/src/client/OTOWNA.cpp
@@ -273,7 +273,7 @@ void TownArray::think_new_independent_town()
 			independentTownCount++;
 	}
 
-	if( independentTownCount >= 10 )		// only when the no. of independent town is less than 10
+	if( independentTownCount >= config.start_up_independent_town )		// only when the no. of independent town is less than the starting amount
 		return;
 
 	//--- if the total population of all nations combined > 1000, then no new independent town will emerge ---//

--- a/src/client/OTOWNA.cpp
+++ b/src/client/OTOWNA.cpp
@@ -251,6 +251,9 @@ void TownArray::think_new_independent_town()
 	if( misc.random(3) != 0 )		// 1/3 chance
 		return;
 
+	if ( !config.new_independent_town_emerge )
+		return;
+
 	//---- count the number of independent towns ----//
 
 	Town* townPtr;


### PR DESCRIPTION
The first patch fixes #36 where independent towns spawn regardless of the configuration option.

The second patch is optional and up for debate. Rather than using a fixed value of max. 10 independent villages, it now uses the number given by the start amount. This will be less for Few (7), and more for More (15) and Many (30), where for many this is a huge increase.
One the one hand, it is more intuitive that the number of villages setting is indicative for the entire game. On the other hand, the game might be better balanced for the amount of 10.