### PR TITLE
Do not apply Quality-of-Life below 30 loyalty.

### DIFF
--- a/src/client/OTOWN.cpp
+++ b/src/client/OTOWN.cpp
@@ -1217,8 +1217,7 @@ void Town::update_target_loyalty()
 		//------- calculate the target loyalty -------//
 
 		targetLoyalty = race_harmony(i+1)/3 +				// 0 to 33
-							 (int)nationPtr->reputation/4 +	// -25 to +25
-							 (quality_of_life-50)/3;				// -17 to +17
+							 (int)nationPtr->reputation/4;	// -25 to +25
 
 		//---- employment help increase loyalty ----//
 
@@ -1302,6 +1301,24 @@ void Town::update_target_loyalty()
 				targetLoyalty = race_target_loyalty_array[j] - thisInfluence;
 				race_target_loyalty_array[j] = MAX(0, targetLoyalty);
 			}
+		}
+	}
+
+	//------- apply quality of life -------//
+
+	int qolContribution = (quality_of_life-50)/3;			// -17 to +17
+	for( i=0 ; i<MAX_RACE ; i++ )
+	{
+		if( race_pop_array[i] == 0 )
+			continue;
+
+		targetLoyalty = race_target_loyalty_array[i];
+
+		// Quality of life only applies to the part above 30 loyalty
+		if (targetLoyalty > 30)
+		{
+			targetLoyalty = MAX(30, targetLoyalty + qolContribution);
+			race_target_loyalty_array[i] = MIN(100, targetLoyalty);
 		}
 	}
 


### PR DESCRIPTION
This change fixes a balancing issue introduced in c390594d246,
which introduced the quality of life, a quantity which influences the loyalty of towns.
Fixes: towns without a fort (such as towns that surrender to you from another player)
no longer rebel after only a short time due to target loyalty becoming less than 30.

------------------

In the application of quality-of-life (QoL), we unwittingly unbalanced the game. When a town surrenders to you, either neutral or from another kingdom, its loyalty starts out at just above 30. The game was balanced as such that, if you had a positive reputation, the town would sit on the edge of 30 loyalty. In effect, this allows you to have the town, but not to use it. You could then build a fort to claim it.
With QoL, this is no longer possible, because of the -17 loyalty hit you incur almost by default and the inevitable rebels that ensue before you can even get a unit close to building a fort. The change created an imbalance.

This patch endeavours to fix this, by applying the QoL only above 30 loyalty. In particular, QoL can not cause the loyalty to drop below 30 and it can not cause a sub-30 loyalty to become bigger. This has the advantage of fixing the above imbalance whilst still being fully meaningful for normal towns (that is, still offering just as much incentive to get trade goods out).

From a lore point of view, I think it's also quite satisfying: you can think of it as Maslow's hierarchy (pyramid) of needs, where quality of life is a luxury product, but this only comes into play when all the layers below have been adequately satisfied.