### PR TITLE
Use snprintf instead of fcvt()

### DIFF
--- a/src/common/OMISC.cpp
+++ b/src/common/OMISC.cpp
@@ -37,6 +37,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <ctype.h>
+#include <math.h>
 
 #include <ALL.h>
 #include <OSTR.h>
@@ -755,10 +756,13 @@ char* Misc::format(double inNum, int formatType)
 
    static char outBuf[35];
    char   *outPtr=outBuf;
+   char   floatBuf[35];
    char   *floatStr;
    int    i, intDigit, sign;    // intDigit = no. of integer digits
 
-   floatStr = fcvt( inNum, MONEY_DEC_PLACE, &intDigit, &sign );
+   intDigit = snprintf(floatBuf, sizeof(floatBuf), "%.0lf", fabs(inNum) * 100.0);
+   intDigit -= 2;
+   floatStr = floatBuf;
 
    #ifdef DEBUG
       if( intDigit > 29 )            // integer digits can't exceed 29


### PR DESCRIPTION
fcvt is deprecated (from gcvt(3)):

    Marked as LEGACY in POSIX.1-2001.  POSIX.1-2008 removes the
    specification of gcvt(), recommending the use of sprintf(3)
    instead (though snprintf(3) may be preferable)

and does not exist on e.g. FreeBSD.