### PR TITLE
kill-gcvt patch: Add necessary include headers

### DIFF
--- a/src/common/OMISC.cpp
+++ b/src/common/OMISC.cpp
@@ -35,6 +35,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <gettext.h> // for snprintf on both C++11 compilers and MSVC++
 #include <time.h>
 #include <ctype.h>
 #include <math.h>


### PR DESCRIPTION
Update to #41 kill-gcvt patch: snprintf requires stdio.h, and on MSVC++ (<2015) we require the gettext.h work-around.