### PR TITLE
Town Networks: Fixed crash when emptying the last village in the town network into a fort via right-clicking the link line

### DIFF
--- a/src/client/OTOWN.cpp
+++ b/src/client/OTOWN.cpp
@@ -221,6 +221,7 @@ void Town::deinit()
 	//------- reset parameters ---------//
 
 	town_recno = 0;
+	town_network_recno = 0;
 }
 //--------- End of function Town::deinit ----------//
 


### PR DESCRIPTION
Fixed crash when emptying the last village in the town network into a fort via right-clicking the link line.
This bug was reported by Einheit 101 in the v2.14.5 discussion thread on the forums.

The solution is very simple: also set the town_network_recno to 0 at town deinit(), as the existing draw-code already checks and handles that situation. 