### PR TITLE
Improvements and bugfixes - September 2015

### DIFF
--- a/include/OMISC.h
+++ b/include/OMISC.h
@@ -69,6 +69,8 @@ public:
    void  rtrim_fld(char*,char*,int);
    int   atoi(char*,int);
 
+   void  dos_encoding_to_win(char *c, int len);
+
    void  empty(char*,int);
    int   is_empty(char*,int=0);
 

--- a/include/openal_audio.h
+++ b/include/openal_audio.h
@@ -76,7 +76,7 @@ private:
 
 	private:
 		/* forbid copying */
-		StreamContext(const StreamContext &) {}
+		StreamContext(const StreamContext &);
 	};
 
 	typedef std::map<int, StreamContext *> StreamMap;

--- a/src/audio/openal/openal_audio.cpp
+++ b/src/audio/openal/openal_audio.cpp
@@ -1122,8 +1122,8 @@ bool OpenALAudio::StreamContext::stream_data(int new_buffer_count)
 		}
 
 		size_t space_frames = BUFFER_SIZE / this->stream->frame_size();
-			space_frames = MIN(space_frames, max_frames);
-			frames_read = this->stream->read(data_buffer, space_frames);
+		space_frames = MIN(space_frames, max_frames);
+		frames_read = this->stream->read(data_buffer, space_frames);
 
 		if (frames_read == 0)
 		{

--- a/src/client/OBULLET.cpp
+++ b/src/client/OBULLET.cpp
@@ -358,7 +358,7 @@ void Bullet::hit_building(short x, short y)
 	if( attackDamage == 0)
 		return;
 
-	Unit *virtualUnit, *parentUnit;
+	Unit *virtualUnit = NULL, *parentUnit;
 	if(unit_array.is_deleted(parent_recno))
 	{
 		parentUnit = NULL;

--- a/src/client/OFIRMIF.cpp
+++ b/src/client/OFIRMIF.cpp
@@ -491,7 +491,7 @@ int Firm::detect_worker_list()
 		x = INFO_X1+6+i%4*50;
 		y = pop_disp_y1+1+i/4*29;
 
-		switch( mouse.single_click(x, y, x+27, y+23, 2) )
+		switch( mouse.any_click(x, y, x+27, y+23, LEFT_BUTTON) ? 1 : (mouse.any_click(x, y, x+27, y+23, RIGHT_BUTTON) ? 2 : 0) )
 		{
 			case 1:         // left button to select worker
 				selected_worker_id = i+1;

--- a/src/client/OF_BASE.cpp
+++ b/src/client/OF_BASE.cpp
@@ -238,8 +238,8 @@ void FirmBase::detect_info()
 
 	//------ detect the overseer button -----//
 
-	int rc = mouse.single_click(INFO_X1+6, INFO_Y1+58,
-				INFO_X1+5+UNIT_LARGE_ICON_WIDTH, INFO_Y1+57+UNIT_LARGE_ICON_HEIGHT, 2 );
+	int rc = mouse.any_click(INFO_X1+6, INFO_Y1+58, INFO_X1+5+UNIT_LARGE_ICON_WIDTH, INFO_Y1+57+UNIT_LARGE_ICON_HEIGHT, LEFT_BUTTON) ? 1 
+		: mouse.any_click(INFO_X1+6, INFO_Y1+58, INFO_X1+5+UNIT_LARGE_ICON_WIDTH, INFO_Y1+57+UNIT_LARGE_ICON_HEIGHT, RIGHT_BUTTON) ? 2 : 0;
 
 	if( rc==1 )		// display this overseer's info
 	{

--- a/src/client/OF_CAMP.cpp
+++ b/src/client/OF_CAMP.cpp
@@ -421,8 +421,8 @@ void FirmCamp::detect_info()
 
 	//------ detect the overseer button -----//
 
-	int rc = mouse.single_click(INFO_X1+6, INFO_Y1+58,
-				INFO_X1+5+UNIT_LARGE_ICON_WIDTH, INFO_Y1+57+UNIT_LARGE_ICON_HEIGHT, 2 );
+	int rc = mouse.any_click(INFO_X1+6, INFO_Y1+58, INFO_X1+5+UNIT_LARGE_ICON_WIDTH, INFO_Y1+57+UNIT_LARGE_ICON_HEIGHT, LEFT_BUTTON) ? 1 
+		: mouse.any_click(INFO_X1+6, INFO_Y1+58, INFO_X1+5+UNIT_LARGE_ICON_WIDTH, INFO_Y1+57+UNIT_LARGE_ICON_HEIGHT, RIGHT_BUTTON) ? 2 : 0;
 
 	if( rc==1 )		// display this overseer's info
 	{

--- a/src/client/OF_MARK.cpp
+++ b/src/client/OF_MARK.cpp
@@ -814,7 +814,7 @@ void FirmMarket::clear_market_goods(int position)
 	}
 	else
 	{
-		market_product_array[marketGoods->raw_id-1] = NULL;
+		market_product_array[marketGoods->product_raw_id-1] = NULL;
 		marketGoods->product_raw_id = 0;
 	}
 }

--- a/src/client/OGAMEMP.cpp
+++ b/src/client/OGAMEMP.cpp
@@ -1737,6 +1737,7 @@ int Game::mp_join_session(int session_id, char *player_name)
 	char password[MP_FRIENDLY_NAME_LEN+1];
 	unsigned long wait_time;
 	int sysMsg;
+	bool joinSessionInitiated = false;
 
 	session = mp_obj.get_session(session_id);
 	err_when(session == NULL);
@@ -1750,7 +1751,9 @@ int Game::mp_join_session(int session_id, char *player_name)
 			MP_FRIENDLY_NAME_LEN+1
 		)
 	)
+	{
 		return 0;
+	}
 
 	strcpy(session->password, password);
 
@@ -1769,6 +1772,7 @@ int Game::mp_join_session(int session_id, char *player_name)
 	{
 		goto END;
 	}
+	joinSessionInitiated = true;
 
 	wait_time = misc.get_time()+30000; // wait for response up to 30 secs
 	while (wait_time > misc.get_time())
@@ -1810,9 +1814,14 @@ END:
 
 	box.close();
 
-	if (sysMsg < 0 || wait_time <= misc.get_time())
+	if (joinSessionInitiated && (sysMsg < 0 || wait_time <= misc.get_time()))
 	{
 		box.msg(_("Unable to connect"));
+		return 0;
+	}
+	else if (!joinSessionInitiated)
+	{
+		box.msg(_("Failed to initiate connection"));
 		return 0;
 	}
 

--- a/src/client/OGAMEMP.cpp
+++ b/src/client/OGAMEMP.cpp
@@ -4957,7 +4957,7 @@ int Game::mp_select_load_option(char *fileName)
 					String str;
 
 					snprintf(str,
-						 255,
+						 MAX_STR_LEN+1,
 						 ngettext("This multiplayer saved game needs %d human players while now there is only %d human player.",
 							  "This multiplayer saved game needs %d human players while now there are only %d human players.",
 							  regPlayerCount),
@@ -5113,7 +5113,7 @@ int Game::mp_select_load_option(char *fileName)
 				String str;
 
 				snprintf(str,
-					 255,
+					 MAX_STR_LEN+1,
 					 ngettext("This multiplayer saved game needs %d human players while now there is only %d human player.",
 						  "This multiplayer saved game needs %d human players while now there are only %d human players.",
 						  playerCount),
@@ -5131,7 +5131,7 @@ int Game::mp_select_load_option(char *fileName)
 			{
 				String str;
 
-				snprintf(str, 255, _("This multiplayer saved game can only support %d human players while now there are %d human players. The game cannot start."), maxPlayer, playerCount);
+				snprintf(str, MAX_STR_LEN+1, _("This multiplayer saved game can only support %d human players while now there are %d human players. The game cannot start."), maxPlayer, playerCount);
 
 				box.msg(str);
 				return 0;

--- a/src/client/ORACERES.cpp
+++ b/src/client/ORACERES.cpp
@@ -171,6 +171,8 @@ void RaceRes::load_name()
 		raceName    = name_array+i-1;
 
 		misc.rtrim_fld( raceName->name, raceNameRec->name, raceNameRec->NAME_LEN );
+		// The default STD.SET uses a different code page than the used fonts.
+		misc.dos_encoding_to_win(raceName->name, raceName->NAME_LEN);
 
 		if( raceName->name[0]=='@' )
 		{

--- a/src/client/OTERRAIN.cpp
+++ b/src/client/OTERRAIN.cpp
@@ -739,7 +739,7 @@ void TerrainRes::load_sub_info()
 	ter_sub_index = (TerrainSubInfo **) mem_add(sizeof(TerrainSubInfo *) * ter_sub_index_count);
 	memset(ter_sub_index, 0, sizeof(TerrainSubInfo *) * ter_sub_index_count);
 
-	TerrainSubInfo *lastTerrainSubInfo;
+	TerrainSubInfo *lastTerrainSubInfo = NULL;
 	for( i=0 ; i < ter_sub_rec_count ; i++ )
 	{
 		terrainSubInfo = ter_sub_array+i;

--- a/src/client/OVOLUME.cpp
+++ b/src/client/OVOLUME.cpp
@@ -70,7 +70,7 @@ RelVolume::RelVolume(PosVolume &posVolume)
 	long absY = posVolume.y >= 0 ? posVolume.y : -posVolume.y;
 	long dist = absX >= absY ? absX :absY;
 	if( dist <= DEFAULT_DIST_LIMIT )
-		rel_vol = rel_vol = 100 - dist * 100 / DEFAULT_VOL_DROP;
+		rel_vol = 100 - dist * 100 / DEFAULT_VOL_DROP;
 	else
 		rel_vol = 0;
 

--- a/src/common/OMISC.cpp
+++ b/src/common/OMISC.cpp
@@ -900,6 +900,32 @@ void Misc::rtrim_fld(char* varPtr, char* fldPtr, int fldLen)
 //---------- End of function Misc::rtrim_fld ---------//
 
 
+//-------- Begin of function Misc::dos_encoding_to_win ---------//
+// Changes the encoding from DOS codepage 437 to the Windows-1252 codepage used by the fonts.
+//
+void Misc::dos_encoding_to_win(char *c, int len)
+{
+	// look up table to convert multilingual char set to windows char set
+	static unsigned char multi_to_win_table[] = 
+		"ÇüéâäàåçêëèïîìÄÅ"
+		"ÉæÆôöòûùÿÖÜø£Ø×\x83"
+		"áíóúñÑªº¿\xae¬½¼¡«»"
+		"?????ÁÂÀ©????¢¥?"
+		"??????ãÃ???????¤"
+		"ðÐÊËÈ'ÍÎÏ????¦Ì?"
+		"ÓßÔÒõÕµÞþÚÛÙýÝ?´"
+		"·±=¾¶§÷?°¨?¹³²??";
+
+
+	unsigned char *textPtr = (unsigned char *)c;
+	for( ; len > 0 && *textPtr; --len, ++textPtr )
+	{
+		if( *textPtr >= 0x80 && multi_to_win_table[*textPtr - 0x80] != '?' )
+			*textPtr = multi_to_win_table[*textPtr - 0x80];
+	}
+}
+//---------- End of function Misc::dos_encoding_to_win ---------//
+
 
 //------- Begin of function Misc::atoi ---------//
 //

--- a/src/input/sdl/OMOUSE.cpp
+++ b/src/input/sdl/OMOUSE.cpp
@@ -537,7 +537,8 @@ int MouseSDL::single_click(int x1, int y1, int x2, int y2,int buttonId)
 // [int] buttonId    = which button ( 0=left, 1-right, 2-left or right)
 //                     (default:0)
 //
-// Return : 1 - if the area has been clicked
+// Return : 1 - if the area has been clicked (left click)
+//				2 - if the area has been clicked (right click)
 //          0 - if not
 //
 int MouseSDL::double_click(int x1, int y1, int x2, int y2,int buttonId)
@@ -569,7 +570,7 @@ int MouseSDL::double_click(int x1, int y1, int x2, int y2,int buttonId)
           && cptr->x >= x1 && cptr->y >= y1
           && cptr->x <= x2 && cptr->y <= y2 )
       {
-         return 1;
+         return 2;
       }
    }
 


### PR DESCRIPTION
Fixes for September 2015:
- Fixed inconvenience in UI where right-clicking on worker-portrait to evict them did not respond to double clicks.
- Fixed issues mentioned in #48, except for the strict-aliasing rules.
- Fixed issue with (potential) buffer overflow when using snprintf with the String class.
- Fixed 3 uninitialised variable uses, none of which I think caused issues so far, but best to have these fixed.
- Fixed issue with accented characters in unit names not displaying properly.

Note:
- Strict-aliasing issues mentioned in #48 will not be immediately solved, but I will keep an eye out for any issues.

This pull request is ready to be included.