### PR TITLE
Also vga.flip() after sys.yield() when a mouse button is being held down

### DIFF
--- a/src/client/OFIRMIF3.cpp
+++ b/src/client/OFIRMIF3.cpp
@@ -198,6 +198,7 @@ void Firm::detect_bribe_menu()
 		while( mouse.left_press )
 		{
 			sys.yield();
+			vga.flip();
 			mouse.get_event();
 		}
 

--- a/src/client/OGAMMENU.cpp
+++ b/src/client/OGAMMENU.cpp
@@ -202,6 +202,7 @@ static int detect_game_option()
 	while( mouse.left_press )	// holding down the button
 	{
 		sys.yield();
+		vga.flip();
 		mouse.get_event();
 	}
 

--- a/src/input/sdl/OMOUSE.cpp
+++ b/src/input/sdl/OMOUSE.cpp
@@ -910,6 +910,7 @@ int MouseSDL::wait_press(int timeOutSecond)
 	while( mouse.left_press || mouse.any_click() || mouse.key_code )		// avoid repeat clicking
 	{
 		sys.yield();
+		vga.flip();
 		mouse.get_event();
 	}
 
@@ -949,6 +950,7 @@ int MouseSDL::wait_press(int timeOutSecond)
 	while( mouse.left_press || mouse.any_click() || mouse.key_code )		// avoid repeat clicking 
 	{
 		sys.yield();
+		vga.flip();
 		mouse.get_event();
 	}
 


### PR DESCRIPTION
Also vga.flip() after sys.yield() when a mouse button is being held down, else the mouse cannot be moved anymore while holding the mouse down.

I've also always wondered how multiplayer handles such modal loops ... I guess it works, just slows the game down?