### PR TITLE
Fixed joining passworded games; fixed compilation with DEBUG defined

### DIFF
--- a/src/client/OGAMEMP.cpp
+++ b/src/client/OGAMEMP.cpp
@@ -1793,7 +1793,7 @@ int Game::mp_join_session(int session_id, char *player_name)
  
 	password[0] = 0;
 	if (
-		session->password[0] &&
+		(session->flags & SESSION_PASSWORD) &&
 		!input_box(
 			_("Enter the game's password:"),
 			password,

--- a/src/multiplayer/common/multiplayer.cpp
+++ b/src/multiplayer/common/multiplayer.cpp
@@ -274,8 +274,6 @@ ENetSocket MultiPlayer::create_socket(uint16_t port)
 	ENetSocket socket;
 	ENetAddress address;
 
-	err_when(!init_flag);
-
 	socket = enet_socket_create(ENET_SOCKET_TYPE_DATAGRAM);
 	if (socket == ENET_SOCKET_NULL)
 		return ENET_SOCKET_NULL;
@@ -295,7 +293,6 @@ ENetSocket MultiPlayer::create_socket(uint16_t port)
 
 void MultiPlayer::destroy_socket(ENetSocket socket)
 {
-	err_when(!init_flag);
 	if (socket != ENET_SOCKET_NULL)
 		enet_socket_destroy(socket);
 }

--- a/src/multiplayer/common/multiplayer.cpp
+++ b/src/multiplayer/common/multiplayer.cpp
@@ -698,7 +698,7 @@ int MultiPlayer::auth_player(uint32_t playerId, char *name, char *password)
 	}
 	player = (PlayerDesc *)peer->data;
 
-	if (memcmp(password, joined_session.password, MP_FRIENDLY_NAME_LEN)) {
+	if ((joined_session.flags & SESSION_PASSWORD) && memcmp(password, joined_session.password, MP_FRIENDLY_NAME_LEN)) {
 		MSG("Player (%d) password is incorrect.\n", playerId);
 		return 0;
 	}

--- a/src/multiplayer/common/multiplayer.cpp
+++ b/src/multiplayer/common/multiplayer.cpp
@@ -693,7 +693,7 @@ int MultiPlayer::auth_player(uint32_t playerId, char *name, char *password)
 	PlayerDesc *player;
 
 	err_when(!host);
-	err_when(!(joined_session & SESSION_HOSTING));
+	err_when(!(joined_session.flags & SESSION_HOSTING));
 
 	peer = get_peer(playerId);
 	if (!peer || !peer->data) {


### PR DESCRIPTION
There were three places in the code that use err_when and that were not updated with the new changes to session.

Detecting if a game had a password still used the old logic (password[0]) rather than checking the flags.