### PR TITLE
Mobilize All Workers from Building [Multiplayer Fixed]

### DIFF
--- a/data/resource/help.res
+++ b/data/resource/help.res
@@ -125,6 +125,10 @@ MAKEWEAP
 _("Make a Weapon")
 _("This takes you to a menu where you can select weapons to make in this war factory.")
 ~
+MOBILIZE
+_("Mobilize Workers")
+_("This will cause all workers to exit the building immediately.")
+~
 MOBILSPY
 _("Mobilize Spy")
 _("This will send the selected spy out of the place where he has been infiltrated.")

--- a/include/OFIRM.h
+++ b/include/OFIRM.h
@@ -334,7 +334,7 @@ public:
 	virtual void next_month();
 	virtual void next_year();
 
-			  void mobilize_all_worker(int leaderUnitRecno);
+			  void mobilize_all_workers(char remoteAction);
 	virtual int	 mobilize_worker(int workerId, char remoteAction);
 			  int	 create_worker_unit(Worker& thisWorker);
 	virtual int  mobilize_overseer();

--- a/include/OREMOTE.h
+++ b/include/OREMOTE.h
@@ -110,6 +110,7 @@ enum { MSG_QUEUE_HEADER=FIRST_REMOTE_MSG_ID,
 		 MSG_FIRM_SET_REPAIR,
 		 MSG_FIRM_TRAIN_LEVEL,
 		 MSG_FIRM_MOBL_WORKER,
+		 MSG_FIRM_MOBL_ALL_WORKERS,
 		 MSG_FIRM_MOBL_OVERSEER,
 		 MSG_FIRM_MOBL_BUILDER,
 		 MSG_FIRM_TOGGLE_LINK_FIRM,
@@ -259,6 +260,7 @@ public:
 	void	firm_set_repair();
 	void	firm_train_level();
 	void	mobilize_worker();
+	void	mobilize_all_workers();
 	void	mobilize_overseer();
 	void	mobilize_builder();
 	void	firm_toggle_link_firm();

--- a/src/client/OFIRM.cpp
+++ b/src/client/OFIRM.cpp
@@ -2572,12 +2572,15 @@ void Firm::mobilize_all_workers(char remoteAction)
 		if (nation_recno == nation_array.player_recno)
 		{
 			Unit* unitPtr = unit_array[unitRecno];
+			unitPtr->team_id = unit_array.cur_team_id;
 			unitPtr->selected_flag = 1;
 			unit_array.selected_count++;
 			if ( !unit_array.selected_recno )
 				unit_array.selected_recno = unitRecno;       // set first worker as selected
 		}
 	}
+
+	unit_array.cur_team_id++;
 
 	if( nation_recno == nation_array.player_recno )		// for player, mobilize_all_workers can only be called when the player presses the button.
 		info.disp();

--- a/src/client/OFIRM.cpp
+++ b/src/client/OFIRM.cpp
@@ -2544,6 +2544,9 @@ int Firm::create_worker_unit(Worker& thisWorker)
 //
 void Firm::mobilize_all_worker(int leaderUnitRecno)
 {
+	if (nation_recno == nation_array.player_recno)
+		power.reset_selection();
+
 	err_when( !worker_array );    // this function shouldn't be called if this firm does not need worker
 
 	//------- detect buttons on hiring firm workers -------//

--- a/src/client/OFIRM.cpp
+++ b/src/client/OFIRM.cpp
@@ -2562,19 +2562,14 @@ void Firm::mobilize_all_worker(int leaderUnitRecno)
 		if(!unitRecno)
 			break; // keep the rest workers as there is no space for creating the unit
 
-		if( leaderUnitRecno )
+		Unit* unitPtr = unit_array[unitRecno];
+		unitPtr->team_id = unit_array.cur_team_id;   // define it as a team
+
+		if (nation_recno == nation_array.player_recno)
 		{
-			Unit* unitPtr = unit_array[unitRecno];
-
-			unitPtr->team_id = unit_array.cur_team_id;   // define it as a team
-			unitPtr->leader_unit_recno = leaderUnitRecno;
-			unitPtr->update_loyalty();							// the unit is just assigned to a new leader, set its target loyalty
-
-			err_when( unitPtr->rank_id != RANK_KING && unitPtr->rank_id != RANK_GENERAL );
-
-			if( nation_recno == nation_array.player_recno )
-				unitPtr->selected_flag = 1;
-      }
+			unitPtr->selected_flag = 1;
+			unit_array.selected_count++;
+		}
 	}
 
    unit_array.cur_team_id++;

--- a/src/client/OFIRM.cpp
+++ b/src/client/OFIRM.cpp
@@ -2574,6 +2574,8 @@ void Firm::mobilize_all_workers(char remoteAction)
 			Unit* unitPtr = unit_array[unitRecno];
 			unitPtr->selected_flag = 1;
 			unit_array.selected_count++;
+			if ( !unit_array.selected_recno )
+				unit_array.selected_recno = unitRecno;       // set first worker as selected
 		}
 	}
 

--- a/src/client/OF_BASE.cpp
+++ b/src/client/OF_BASE.cpp
@@ -51,6 +51,7 @@
 //----------- Define static vars -------------//
 
 static Button3D   button_invoke, button_reward;
+static Button3D	button_vacate_firm;
 
 //--------- Begin of function FirmBase::FirmBase ---------//
 //
@@ -197,7 +198,9 @@ void FirmBase::put_info(int refreshFlag)
 		if( refreshFlag==INFO_REPAINT )
 		{
 			button_invoke.paint( INFO_X1, y, 'A', "INVOKE" );
-			button_reward.paint( INFO_X1+BUTTON_ACTION_WIDTH, y, 'A', "REWARDSP" );
+			button_reward.paint( INFO_X1 + BUTTON_ACTION_WIDTH, y, 'A', "REWARDSP" );
+			button_vacate_firm.paint(INFO_X1 + BUTTON_ACTION_WIDTH * 2, y, 'A', "RECRUIT");
+			button_vacate_firm.set_help_code("Mobilize all workers");
 		}
 
 		if( can_invoke() )
@@ -216,7 +219,12 @@ void FirmBase::put_info(int refreshFlag)
 			button_reward.disable();
 		}
 
-		x=INFO_X1+BUTTON_ACTION_WIDTH*2;
+		if (worker_count)
+			button_vacate_firm.enable();
+		else
+			button_vacate_firm.disable();
+
+		x=INFO_X1+BUTTON_ACTION_WIDTH * 3;
 	}
 	else
 		x=INFO_X1;
@@ -307,6 +315,14 @@ void FirmBase::detect_info()
 		// ##### begin Gilbert 26/9 ########//
 		se_ctrl.immediate_sound("TURN_ON");
 		// ##### end Gilbert 26/9 ########//
+	}
+
+	//-------- detect mobilize button ----------//
+
+	if (button_vacate_firm.detect())
+	{
+		mobilize_all_worker(0);
+		info.disp();
 	}
 }
 //----------- End of function FirmBase::detect_info -----------//

--- a/src/client/OF_BASE.cpp
+++ b/src/client/OF_BASE.cpp
@@ -319,10 +319,9 @@ void FirmBase::detect_info()
 
 	//-------- detect mobilize button ----------//
 
-	if (button_vacate_firm.detect())
+	if( button_vacate_firm.detect() )
 	{
-		mobilize_all_worker(0);
-		info.disp();
+		mobilize_all_workers(COMMAND_PLAYER);
 	}
 }
 //----------- End of function FirmBase::detect_info -----------//

--- a/src/client/OF_BASE.cpp
+++ b/src/client/OF_BASE.cpp
@@ -200,7 +200,7 @@ void FirmBase::put_info(int refreshFlag)
 			button_invoke.paint( INFO_X1, y, 'A', "INVOKE" );
 			button_reward.paint( INFO_X1 + BUTTON_ACTION_WIDTH, y, 'A', "REWARDSP" );
 			button_vacate_firm.paint(INFO_X1 + BUTTON_ACTION_WIDTH * 2, y, 'A', "RECRUIT");
-			button_vacate_firm.set_help_code("Mobilize all workers");
+			button_vacate_firm.set_help_code("MOBILIZE");
 		}
 
 		if( can_invoke() )

--- a/src/client/OF_CAMP.cpp
+++ b/src/client/OF_CAMP.cpp
@@ -641,7 +641,7 @@ void FirmCamp::next_day()
 
 //------- Begin of function FirmCamp::train_unit -------//
 //
-// Increase the leadership and ocmbat level of the general and the soldiers.
+// Increase the leadership and combat level of the general and the soldiers.
 //
 void FirmCamp::train_unit()
 {
@@ -944,21 +944,25 @@ int FirmCamp::patrol_all_soldier()
 		if(!unitRecno)
 			return 0; // keep the rest workers as there is no space for creating the unit
 
+		Unit* unitPtr = unit_array[unitRecno];
+
+		unitPtr->team_id = unit_array.cur_team_id;   // define it as a team
+
 		if(overseer_recno)
 		{
-			Unit* unitPtr = unit_array[unitRecno];
-			unitPtr->team_id = unit_array.cur_team_id;   // define it as a team
 			unitPtr->leader_unit_recno = overseer_recno;
 			unitPtr->update_loyalty();							// the unit is just assigned to a new leader, set its target loyalty
 
 			err_when( unit_array[overseer_recno]->rank_id != RANK_KING &&
 					  unit_array[overseer_recno]->rank_id != RANK_GENERAL );
+		}
 
-			if( nation_recno == nation_array.player_recno )
-			{
-				unitPtr->selected_flag = 1;
-				unit_array.selected_count++;
-			}
+		if( nation_recno == nation_array.player_recno )
+		{
+			unitPtr->selected_flag = 1;
+			unit_array.selected_count++;
+			if ( !unit_array.selected_recno )
+				unit_array.selected_recno = unitRecno;       // set the first soldier as selected; this is also the soldier with the highest leadership (because of sorting)
 		}
 	}
 

--- a/src/client/OF_FACT.cpp
+++ b/src/client/OF_FACT.cpp
@@ -282,8 +282,7 @@ void FirmFactory::detect_info()
 
 	if (button_vacate_firm.detect())
 	{		
-		mobilize_all_worker(0);
-		info.disp();
+		mobilize_all_workers(COMMAND_PLAYER);
 	}
 }
 //----------- End of function FirmFactory::detect_info -----------//

--- a/src/client/OF_FACT.cpp
+++ b/src/client/OF_FACT.cpp
@@ -51,6 +51,7 @@
 //------- define static vars -------//
 
 static Button3D	button_change_production;
+static Button3D	button_vacate_firm;
 
 //--------- Begin of function FirmFactory::FirmFactory ---------//
 //
@@ -214,17 +215,26 @@ void FirmFactory::put_info(int refreshFlag)
 	disp_worker_list(INFO_Y1+126, refreshFlag);
 	disp_worker_info(INFO_Y1+190, refreshFlag);
 
-	//------ display button -------//
+	//------ display mobilize button -------//
 
-	int x;
+	int x = INFO_X1;
 
-	if( own_firm() && refreshFlag==INFO_REPAINT )
+	if(own_firm())
 	{
-		button_change_production.paint( INFO_X1, INFO_Y1+248, 'A', "CHGPROD" );
-		x = INFO_X1+BUTTON_ACTION_WIDTH;
+		if (refreshFlag == INFO_REPAINT)
+		{
+			button_change_production.paint(INFO_X1, INFO_Y1 + 248, 'A', "CHGPROD");
+			button_vacate_firm.paint(INFO_X1 + BUTTON_ACTION_WIDTH, INFO_Y1 + 248, 'A', "RECRUIT");
+			button_vacate_firm.set_help_code("Mobilize all workers");
+		}
+
+		if (worker_count)
+			button_vacate_firm.enable();
+		else
+			button_vacate_firm.disable();
+
+		x += (BUTTON_ACTION_WIDTH * 2);
 	}
-	else
-		x = INFO_X1;
 
 	//---------- display spy button ----------//
 
@@ -266,6 +276,14 @@ void FirmFactory::detect_info()
 		// ##### begin Gilbert 25/9 ######//
 		se_ctrl.immediate_sound("TURN_ON");
 		// ##### end Gilbert 25/9 ######//
+	}
+
+	//-------- detect mobilize button ----------//
+
+	if (button_vacate_firm.detect())
+	{		
+		mobilize_all_worker(0);
+		info.disp();
 	}
 }
 //----------- End of function FirmFactory::detect_info -----------//

--- a/src/client/OF_FACT.cpp
+++ b/src/client/OF_FACT.cpp
@@ -225,7 +225,7 @@ void FirmFactory::put_info(int refreshFlag)
 		{
 			button_change_production.paint(INFO_X1, INFO_Y1 + 248, 'A', "CHGPROD");
 			button_vacate_firm.paint(INFO_X1 + BUTTON_ACTION_WIDTH, INFO_Y1 + 248, 'A', "RECRUIT");
-			button_vacate_firm.set_help_code("Mobilize all workers");
+			button_vacate_firm.set_help_code("MOBILIZE");
 		}
 
 		if (worker_count)

--- a/src/client/OF_MINE.cpp
+++ b/src/client/OF_MINE.cpp
@@ -199,7 +199,7 @@ void FirmMine::put_info(int refreshFlag)
 	if (own_firm() && refreshFlag == INFO_REPAINT)
 	{
 		button_vacate_firm.paint(INFO_X1 + BUTTON_ACTION_WIDTH, INFO_Y1 + 248, 'A', "RECRUIT");
-		button_vacate_firm.set_help_code("Mobilize all workers");
+		button_vacate_firm.set_help_code("MOBILIZE");
 
 		if (worker_count)
 			button_vacate_firm.enable();

--- a/src/client/OF_MINE.cpp
+++ b/src/client/OF_MINE.cpp
@@ -244,8 +244,7 @@ void FirmMine::detect_info()
 
 	if (button_vacate_firm.detect())
 	{
-		mobilize_all_worker(0);
-		info.disp();
+		mobilize_all_workers(COMMAND_PLAYER);
 	}
 }
 //----------- End of function FirmMine::detect_info -----------//

--- a/src/client/OF_MINE.cpp
+++ b/src/client/OF_MINE.cpp
@@ -35,7 +35,12 @@
 #include <OSITE.h>
 #include <OF_MINE.h>
 #include <OF_FACT.h>
+#include <OBUTT3D.h>
 #include "gettext.h"
+
+//------- define static vars -------//
+
+static Button3D	button_vacate_firm;
 
 //--------- Begin of function FirmMine::FirmMine ---------//
 //
@@ -187,9 +192,26 @@ void FirmMine::put_info(int refreshFlag)
 	disp_worker_list(INFO_Y1+127, refreshFlag);
 	disp_worker_info(INFO_Y1+191, refreshFlag);
 
+	//------ display mobilize button -------//
+
+	int x = INFO_X1;
+
+	if (own_firm() && refreshFlag == INFO_REPAINT)
+	{
+		button_vacate_firm.paint(INFO_X1 + BUTTON_ACTION_WIDTH, INFO_Y1 + 248, 'A', "RECRUIT");
+		button_vacate_firm.set_help_code("Mobilize all workers");
+
+		if (worker_count)
+			button_vacate_firm.enable();
+		else
+			button_vacate_firm.disable();
+
+		x += BUTTON_ACTION_WIDTH;
+	}
+
 	//---------- display spy button ----------//
 
-	disp_spy_button(INFO_X1, INFO_Y1+249, refreshFlag);
+	disp_spy_button(x, INFO_Y1+249, refreshFlag);
 }
 //----------- End of function FirmMine::put_info -----------//
 
@@ -217,6 +239,14 @@ void FirmMine::detect_info()
 
 	if( !own_firm() )
 		return;
+
+	//-------- detect mobilize button ----------//
+
+	if (button_vacate_firm.detect())
+	{
+		mobilize_all_worker(0);
+		info.disp();
+	}
 }
 //----------- End of function FirmMine::detect_info -----------//
 

--- a/src/client/OF_MINE.cpp
+++ b/src/client/OF_MINE.cpp
@@ -198,7 +198,7 @@ void FirmMine::put_info(int refreshFlag)
 
 	if (own_firm() && refreshFlag == INFO_REPAINT)
 	{
-		button_vacate_firm.paint(INFO_X1 + BUTTON_ACTION_WIDTH, INFO_Y1 + 248, 'A', "RECRUIT");
+		button_vacate_firm.paint(INFO_X1, INFO_Y1 + 249, 'A', "RECRUIT");
 		button_vacate_firm.set_help_code("MOBILIZE");
 
 		if (worker_count)

--- a/src/client/OF_MINE.cpp
+++ b/src/client/OF_MINE.cpp
@@ -196,10 +196,13 @@ void FirmMine::put_info(int refreshFlag)
 
 	int x = INFO_X1;
 
-	if (own_firm() && refreshFlag == INFO_REPAINT)
+	if (own_firm())
 	{
-		button_vacate_firm.paint(INFO_X1, INFO_Y1 + 249, 'A', "RECRUIT");
-		button_vacate_firm.set_help_code("MOBILIZE");
+		if (refreshFlag == INFO_REPAINT)
+		{
+			button_vacate_firm.paint(INFO_X1, INFO_Y1 + 249, 'A', "RECRUIT");
+			button_vacate_firm.set_help_code("MOBILIZE");
+		}
 
 		if (worker_count)
 			button_vacate_firm.enable();

--- a/src/client/OF_RESE.cpp
+++ b/src/client/OF_RESE.cpp
@@ -162,7 +162,7 @@ void FirmResearch::disp_main_menu(int refreshFlag)
 		{
 			button_select_research.paint(INFO_X1, INFO_Y1 + 235, 'A', "RESEARCH");
 			button_vacate_firm.paint(INFO_X1 + BUTTON_ACTION_WIDTH, INFO_Y1 + 235, 'A', "RECRUIT");
-			button_vacate_firm.set_help_code("Mobilize all workers");
+			button_vacate_firm.set_help_code("MOBILIZE");
 		}
 
 		if (worker_count)

--- a/src/client/OF_RESE.cpp
+++ b/src/client/OF_RESE.cpp
@@ -216,8 +216,7 @@ void FirmResearch::detect_main_menu()
 
 	if (button_vacate_firm.detect())
 	{
-		mobilize_all_worker(0);
-		info.disp();
+		mobilize_all_workers(COMMAND_PLAYER);
 	}
 }
 //----------- End of function FirmResearch::detect_main_menu -----------//

--- a/src/client/OF_RESE.cpp
+++ b/src/client/OF_RESE.cpp
@@ -65,6 +65,7 @@ static ButtonCustom	button_research_array[MAX_RESEARCH_OPTION];
 static ButtonCustom	button_cancel;
 // ######## end Gilbert 16/8 ######//
 static int added_count;			// no. of buttons in button_research_array
+static Button3D	button_vacate_firm;
 
 //---------- Declare static functions ---------//
 
@@ -148,18 +149,31 @@ void FirmResearch::disp_main_menu(int refreshFlag)
 		return;
 
 	disp_research_info(INFO_Y1+54, refreshFlag);
-
 	disp_worker_list(INFO_Y1+107, refreshFlag);
-
 	disp_worker_info(INFO_Y1+171, refreshFlag);
+
+	//------ display mobilize button -------//
+
+	int x = INFO_X1;
 
 	if( own_firm() )
 	{
-		if( refreshFlag==INFO_REPAINT )
-			button_select_research.paint( INFO_X1, INFO_Y1+235, 'A', "RESEARCH" );
+		if (refreshFlag == INFO_REPAINT)
+		{
+			button_select_research.paint(INFO_X1, INFO_Y1 + 235, 'A', "RESEARCH");
+			button_vacate_firm.paint(INFO_X1 + BUTTON_ACTION_WIDTH, INFO_Y1 + 235, 'A', "RECRUIT");
+			button_vacate_firm.set_help_code("Mobilize all workers");
+		}
+
+		if (worker_count)
+			button_vacate_firm.enable();
+		else
+			button_vacate_firm.disable();
+
+		x += (BUTTON_ACTION_WIDTH * 2);
 	}
 
-	disp_spy_button( INFO_X1+BUTTON_ACTION_WIDTH, INFO_Y1+235, refreshFlag );
+	disp_spy_button( x, INFO_Y1+235, refreshFlag );
 }
 //----------- End of function FirmResearch::disp_main_menu -----------//
 
@@ -196,6 +210,14 @@ void FirmResearch::detect_main_menu()
 		disable_refresh = 1;    // static var for disp_info() only
 		info.disp();
 		disable_refresh = 0;
+	}
+
+	//-------- detect mobilize button ----------//
+
+	if (button_vacate_firm.detect())
+	{
+		mobilize_all_worker(0);
+		info.disp();
 	}
 }
 //----------- End of function FirmResearch::detect_main_menu -----------//

--- a/src/client/OF_WAR.cpp
+++ b/src/client/OF_WAR.cpp
@@ -233,8 +233,7 @@ void FirmWar::detect_main_menu()
 
 	if (button_vacate_firm.detect())
 	{
-		mobilize_all_worker(0);
-		info.disp();
+		mobilize_all_workers(COMMAND_PLAYER);
 	}
 }
 //----------- End of function FirmWar::detect_main_menu -----------//

--- a/src/client/OF_WAR.cpp
+++ b/src/client/OF_WAR.cpp
@@ -76,6 +76,7 @@ static ButtonCustom button_weapon[MAX_WEAPON_TYPE];
 static ButtonCustom button_queue_weapon[MAX_WEAPON_TYPE];
 // ###### end Gilbert 10/9 #######//
 static ButtonCustom button_cancel;
+static Button3D	button_vacate_firm;
 
 
 // --------- declare static function ----------//
@@ -156,13 +157,28 @@ void FirmWar::disp_main_menu(int refreshFlag)
 
 	disp_worker_info(INFO_Y1+171, refreshFlag);
 
-	if( own_firm() )
+	//------ display mobilize button -------//
+
+	int x = INFO_X1;
+
+	if (own_firm())
 	{
-		if( refreshFlag==INFO_REPAINT )
-			button_select_build.paint( INFO_X1, INFO_Y1+235, 'A', "MAKEWEAP" );
+		if (refreshFlag == INFO_REPAINT)
+		{	
+			button_select_build.paint(INFO_X1, INFO_Y1 + 235, 'A', "MAKEWEAP");
+			button_vacate_firm.paint(INFO_X1 + BUTTON_ACTION_WIDTH, INFO_Y1 + 235, 'A', "RECRUIT");
+			button_vacate_firm.set_help_code("Mobilize all workers");
+		}
+
+		if (worker_count)
+			button_vacate_firm.enable();
+		else
+			button_vacate_firm.disable();
+
+		x += (BUTTON_ACTION_WIDTH * 2);
 	}
 
-	disp_spy_button( INFO_X1+BUTTON_ACTION_WIDTH, INFO_Y1+235, refreshFlag );
+	disp_spy_button( x, INFO_Y1+235, refreshFlag );
 }
 //----------- End of function FirmWar::disp_main_menu -----------//
 
@@ -211,6 +227,14 @@ void FirmWar::detect_main_menu()
 		disable_refresh = 1;    // static var for disp_info() only
 		info.disp();
 		disable_refresh = 0;
+	}
+
+	//-------- detect mobilize button ----------//
+
+	if (button_vacate_firm.detect())
+	{
+		mobilize_all_worker(0);
+		info.disp();
 	}
 }
 //----------- End of function FirmWar::detect_main_menu -----------//

--- a/src/client/OF_WAR.cpp
+++ b/src/client/OF_WAR.cpp
@@ -167,7 +167,7 @@ void FirmWar::disp_main_menu(int refreshFlag)
 		{	
 			button_select_build.paint(INFO_X1, INFO_Y1 + 235, 'A', "MAKEWEAP");
 			button_vacate_firm.paint(INFO_X1 + BUTTON_ACTION_WIDTH, INFO_Y1 + 235, 'A', "RECRUIT");
-			button_vacate_firm.set_help_code("Mobilize all workers");
+			button_vacate_firm.set_help_code("MOBILIZE");
 		}
 
 		if (worker_count)

--- a/src/multiplayer/common/OREMOTEM.cpp
+++ b/src/multiplayer/common/OREMOTEM.cpp
@@ -111,6 +111,7 @@ static MsgProcessFP msg_process_function_array[] =
 	&RemoteMsg::firm_set_repair,
 	&RemoteMsg::firm_train_level,
 	&RemoteMsg::mobilize_worker,
+	&RemoteMsg::mobilize_all_workers,
 	&RemoteMsg::mobilize_overseer,
 	&RemoteMsg::mobilize_builder,
 	&RemoteMsg::firm_toggle_link_firm,
@@ -1569,6 +1570,24 @@ void RemoteMsg::mobilize_worker()
 	}
 }
 // ------- End of function RemoteMsg::mobilize_worker ---------//
+
+
+// ------- Begin of function RemoteMsg::mobilize_all_workers ---------//
+void RemoteMsg::mobilize_all_workers()
+{
+	err_when( id != MSG_FIRM_MOBL_ALL_WORKERS );
+	// packet structure : <firm recno>
+	short *shortPtr = (short *)data_buf;
+
+	if( validate_firm(*shortPtr) )
+	{
+#ifdef DEBUG_LONG_LOG
+		long_log->printf("firm %d mobilize all workers\n", shortPtr[0]);
+#endif
+		firm_array[*shortPtr]->mobilize_all_workers(COMMAND_REMOTE);
+	}
+}
+// ------- End of function RemoteMsg::mobilize_all_workers ---------//
 
 
 // ------- Begin of function RemoteMsg::mobilize_overseer ---------//


### PR DESCRIPTION
This is an update to pull #51. This fixes the issue with multiplayer not being handled, as well as the mouse 'squiggly' arrow / hover-feedback not being present. I've also removed the team code.

@sraboy Please check commit 0d6f990 to see if it is correct. You can also check the first, 9d62bb1, to see how multiplayer messages are implemented and used in Seven Kingdoms.