### PR TITLE
OAI_SPY: Fix conditional which made ai_find_spy always fail.

### DIFF
--- a/src/client/OAI_SPY.cpp
+++ b/src/client/OAI_SPY.cpp
@@ -212,7 +212,7 @@ Spy* Nation::ai_find_spy(int targetXLoc, int targetYLoc, int spyRaceId, int mobi
 
 		spyPtr = spy_array[i];
 
-		if( !spyPtr->true_nation_recno != nation_recno )
+		if( spyPtr->true_nation_recno != nation_recno )
 			continue;
 
 		if( spyRaceId && spyRaceId != race_id )


### PR DESCRIPTION
I did find one interesting thing from the warnings in issue #63, in OAI_SPY.cpp, function `Nation::ai_find_spy`:

    if( !spyPtr->true_nation_recno != nation_recno )

Notice the extra `!` which `-Wlogical-not-parentheses` found for us.

This means that the AI was never able to to find a spy to reuse and *always* had to go and find new spies to do the job. Fixing this should mean that the AI will reuse spies in its own towns and firms more often.