### PR TITLE
Call "audio.deinit()" before exit.

### DIFF
--- a/src/audio/openal/openal_audio.cpp
+++ b/src/audio/openal/openal_audio.cpp
@@ -168,7 +168,8 @@ OpenALAudio::OpenALAudio()
 
 OpenALAudio::~OpenALAudio()
 {
-	this->deinit();
+	if (this->init_flag != 0)
+		this->deinit();
 }
 
 // Initialize the mid driver

--- a/src/client/OMUSIC.cpp
+++ b/src/client/OMUSIC.cpp
@@ -81,7 +81,8 @@ Music::Music()
 // -------- begin of function Music::~Music ---------//
 Music::~Music()
 {
-	deinit();
+	if (init_flag != 0)
+		deinit();
 }
 // -------- end of function Music::~Music ---------//
 

--- a/src/client/OSYS.cpp
+++ b/src/client/OSYS.cpp
@@ -226,6 +226,8 @@ void Sys::deinit()
    if( !init_flag )
       return;
 
+   music.deinit();
+   audio.deinit();
    game.deinit();    // actually game.deinit() will be called by main_win_proc() and calling it here will have no effect
 
    deinit_objects();

--- a/src/client/OSYS.cpp
+++ b/src/client/OSYS.cpp
@@ -226,8 +226,6 @@ void Sys::deinit()
    if( !init_flag )
       return;
 
-   music.deinit();
-   audio.deinit();
    game.deinit();    // actually game.deinit() will be called by main_win_proc() and calling it here will have no effect
 
    deinit_objects();
@@ -241,6 +239,8 @@ void Sys::deinit()
       vga_front.unlock_buf();
 
    //-------------------------------------//
+
+   deinit_directx();
 
    init_flag = 0;
 }

--- a/src/video/sdl/vga_sdl.cpp
+++ b/src/video/sdl/vga_sdl.cpp
@@ -58,7 +58,8 @@ VgaSDL::VgaSDL()
 
 VgaSDL::~VgaSDL()
 {
-   deinit();
+   if (window != NULL)
+      deinit();
 }
 //-------- End of function VgaSDL::~VgaSDL ----------//
 


### PR DESCRIPTION
Fixes issue #69.