### PR TITLE
C++11 compiler flag for configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,8 @@ AC_PROG_RANLIB
 AC_PROG_LN_S
 PKG_PROG_PKG_CONFIG
 
+AX_CXX_COMPILE_STDCXX_11(,[mandatory])
+
 # Checks for header files.
 dnl AC_CHECK_HEADERS([])
 

--- a/include/GAMEDEF.h
+++ b/include/GAMEDEF.h
@@ -50,24 +50,24 @@ extern const int GAME_VERSION;
 #define CONFIG_APPLICATION_NAME "7kaa"
 
 // top level data dirs
-#define DEFAULT_DIR_RES      "resource"PATH_DELIM
-#define DEFAULT_DIR_SPRITE   "sprite"PATH_DELIM
-#define DEFAULT_DIR_SOUND    "sound"PATH_DELIM
-#define DEFAULT_DIR_IMAGE    "image"PATH_DELIM
-#define DEFAULT_DIR_ENCYC    "encyc"PATH_DELIM
-#define DEFAULT_DIR_ENCYC2   "encyc2"PATH_DELIM
-#define DEFAULT_DIR_MOVIE    "movie"PATH_DELIM
-#define DEFAULT_DIR_MUSIC    "music"PATH_DELIM
-#define DEFAULT_DIR_TUTORIAL "tutorial"PATH_DELIM
-#define DEFAULT_DIR_SCENARIO "scenario"PATH_DELIM
-#define DEFAULT_DIR_SCENARI2 "scenari2"PATH_DELIM
+#define DEFAULT_DIR_RES      "resource" PATH_DELIM
+#define DEFAULT_DIR_SPRITE   "sprite" PATH_DELIM
+#define DEFAULT_DIR_SOUND    "sound" PATH_DELIM
+#define DEFAULT_DIR_IMAGE    "image" PATH_DELIM
+#define DEFAULT_DIR_ENCYC    "encyc" PATH_DELIM
+#define DEFAULT_DIR_ENCYC2   "encyc2" PATH_DELIM
+#define DEFAULT_DIR_MOVIE    "movie" PATH_DELIM
+#define DEFAULT_DIR_MUSIC    "music" PATH_DELIM
+#define DEFAULT_DIR_TUTORIAL "tutorial" PATH_DELIM
+#define DEFAULT_DIR_SCENARIO "scenario" PATH_DELIM
+#define DEFAULT_DIR_SCENARI2 "scenari2" PATH_DELIM
 
 // encylopedia chapter dirs
-#define DEFAULT_DIR_ENCYC_UNIT    "unit"PATH_DELIM
-#define DEFAULT_DIR_ENCYC_FIRM    "firm"PATH_DELIM
-#define DEFAULT_DIR_ENCYC_SEAT    "seat"PATH_DELIM
-#define DEFAULT_DIR_ENCYC_GOD     "god"PATH_DELIM
-#define DEFAULT_DIR_ENCYC_MONSTER "monster"PATH_DELIM
+#define DEFAULT_DIR_ENCYC_UNIT    "unit" PATH_DELIM
+#define DEFAULT_DIR_ENCYC_FIRM    "firm" PATH_DELIM
+#define DEFAULT_DIR_ENCYC_SEAT    "seat" PATH_DELIM
+#define DEFAULT_DIR_ENCYC_GOD     "god" PATH_DELIM
+#define DEFAULT_DIR_ENCYC_MONSTER "monster" PATH_DELIM
 
 #define DIR_RES         DEFAULT_DIR_RES
 #define DIR_SPRITE      DEFAULT_DIR_SPRITE


### PR DESCRIPTION
C++11 compiler flag for configure.ac and fixed some warnings that were replicated many times over.

Related discussion on forum: https://www.7kfans.com/forums/viewtopic.php?f=20&t=899