### PR TITLE
Russian translation and manual 

### DIFF
--- a/doc/buildings_workers_links.tex
+++ b/doc/buildings_workers_links.tex
@@ -85,7 +85,7 @@ You will be able to Sell your building by \textbf{Clicking} on the \$ Icon. Th
 	\vspace{-20pt}
 \end{wrapfigure}
 
-If your building is more than 20\% damaged you will no longer have the option of selling it. You may either demolish it or repair it. You may demolish a building by Clicking on the Wrecking Ball Icon. You will recoup no money when you demolish a building.
+If your building is more than 20\% damaged you will no longer have the option of selling it. You may either demolish it or repair it. You may demolish a building by \textbf{Clicking} on the Wrecking Ball Icon. You will recoup no money when you demolish a building.
 
 You may also demolish your building before you have finished its construction.
 
@@ -192,13 +192,13 @@ An open Link means that goods, money, people and influence can flow between both
 	\vspace{-20pt}
 \end{wrapfigure}
 
-% bug here 
+% DIRTY HACK HERE 
 
-You may close an open Link by \textbf{Clicking} inside the rotating yellow and green ring. The ring will then change to a green X.
+You may close an open Link by \textbf{Clicking} inside the rotating \\
+yellow and green ring. The ring will \\
+then change to a green X.
 
 All flow between the two ends of the Link will then cease. This is useful for controlling the number of workers who can volunteer to work in your structures, as well as for controlling the flow of goods and raw materials.
-
-%\clearpage
 
 \section{Inactive Links}
 

--- a/doc/creating_empire.tex
+++ b/doc/creating_empire.tex
@@ -119,9 +119,7 @@ You will be notified with a news message when these people have chosen to join y
 
 It is possible that some of these immigrants are in fact Spies in the pay of an enemy Kingdom.
 
-% change chapter #
-
-See \textbf{Chapter 15} for details on Spying.
+See \textbf{Chapter 17} for details on Spying.
 
 On occasion, entire Independent Villages or enemy-controlled Villages may decide to join your Empire. They will only do this if your Kingdom has a very high Reputation and if they believe you are powerful enough to protect them.
 

--- a/doc/credits.tex
+++ b/doc/credits.tex
@@ -63,7 +63,7 @@ External Playtesters	& Jim Pedicord, Marcus Nelson, Gino Costa, Matt McKeehan, G
 \begin{tabular}{ | p{4cm} | p{9cm} |}
 	\hline
 	Programming	& Jesse Allen, Jeffrey LaCombe, Jeffrey Finkelstein, Alex Streit, Aleksey V, L. Alberto Giménez, Martin DP, Unavowed, Erik Lissel, toaster, Richard Dijk, Daniel Santos, Alejandro Ramirez, Elmo Todurov, Steve Lavoie, Dmitry Marakasov, Ralf Lang, Keegan Drake H.P, Sauron, Bretislav Stec, Timothy Rink \\ \hline
-Manual & Timothy Rink \\ \hline
+Manual & Timothy Rink, Jeffrey LaCombe, Jesse Allen, Richard Dijk \\ \hline
 Russian Translation	& Olya Kudryavtseva, Vlad Klevtsov, Elena Zasutskaya, Natalie Feotistova \\ \hline
 Special Thanks	& Trevor Chan, Every 7kfan \\ \hline
 	\hline

--- a/doc/developing_your_economy.tex
+++ b/doc/developing_your_economy.tex
@@ -389,6 +389,8 @@ Your Caravan will go to that Market and return with a load of that Raw Material.
 
 You may set the stop for that Caravan to return to as your Factory or your Market.
 
+% BUG HERE
+
 If you set the Market, your Caravan will drop off its goods there and then go back for another load. Your Factory will then take the Raw Materials from the Market and use them to produce the Finished Goods.
 
 If you send the Caravan to the Factory, you will produce the Finished Goods as before, but you will leave one space free in your Market for other goods. For this reason, it is the preferred method.

--- a/doc/force_and_its_use.tex
+++ b/doc/force_and_its_use.tex
@@ -154,9 +154,9 @@ When a Troop is selected you may order an attack on enemy Soldiers or on an enem
 
 You may, if you wish, assign a number to a Troop, several Troops, or any group of people, Weapons, and / or Ships.
 
-To do this, first \textbf{Select} or \textbf{Group-Select} the units that you want to number. Then press \textbf{Ctrl} + <\textbf{number 0–9}>.
+To do this, first \textbf{Select} or \textbf{Group-Select} the units that you want to number. Then press \textbf{Ctrl} + \textbf{number 0–9}.
 
-To recall a numbered group, press \textbf{Alt} + <\textbf{number 0-9}>.
+To recall a numbered group, press \textbf{Alt} + \textbf{number 0-9}.
 
 Troops in a numbered group will lose their number if they return to their Fort. You may not, therefore, recall a numbered troop from its Fort.
 

--- a/doc/information_interface.tex
+++ b/doc/information_interface.tex
@@ -29,7 +29,7 @@ On the top of your screen you will see all of the information necessary to keep 
 
 Beginning on the Left you will see the Scrolls. \textbf{Click} on a Scroll to see the detailed information inside each. You may also access these Scrolls by pressing the \textbf{F1} through \textbf{F8} keys on your keyboard.
 
-Once you have opened one of these Scrolls, it can be closed by \textsl{Clicking} it again or by pressing the \textbf{Esc} key on your keyboard.
+Once you have opened one of these Scrolls, it can be closed by \textbf{}{Clicking} it again or by pressing the \textbf{Esc} key on your keyboard.
 
 \section{Kingdoms}
 
@@ -73,8 +73,8 @@ If you accept a Cease Fire in a war, the Allow Attack option with the other sign
 It would be very wise of you to set the Allow Attack option to No for every Kingdom that you are not planning to attack. This will prevent the sometimes unavoidable incidents of friendly-fire casualties from blowing up into full-scale war. If you are set to No, the other Kingdom will understand that any such incident was just a mistake.
 
 \subsection{Diplomacy and Diplomatic Log}
-% add internal link/change chapter #
-For these two buttons, see the detailed descriptions in Chapter 11.
+
+For these two buttons, see the detailed descriptions in Chapter 13.
 
 \section{Villages}
 
@@ -348,7 +348,7 @@ Units of other Kingdoms will try to walk around your borders in their travels. T
 
 Whenever you \textbf{Click} on one of your units you will be presented with information showing that unit’s Color, Name, Hit-Points, Loyalty Level, Combat Skill Level, Leadership Level, and Contribution Total.
 
-Every person in the world of 7kaa bears a unique name.
+Every person in the world of \textit{Seven Kingdoms: Ancient Adversaries} bears a unique name.
 
 To center a selected Person, Weapon, Ship, Caravan or Building on the main screen, \textbf{Click} on its name.
 

--- a/doc/installation_start-up.tex
+++ b/doc/installation_start-up.tex
@@ -23,7 +23,7 @@
 
 \section{Minimum Requirements}
 
-To play 7kaa, the following hardware and software is required:
+To play \textit{Seven Kingdoms: Ancient Adversaries}, the following hardware and software is required:
 
 \begin{adjustwidth}{1cm}{}
 x86 or x86\_64 processor, Pentium or better \\
@@ -33,9 +33,11 @@ SDL2.0 with accelerated OpenGl or DirectX compliant video drivers \\
 
 \subsection{Optional Requirements}
 
+\begin{adjustwidth}{1cm}{}
 UDP/IP connection for LAN and Internet play
+\end{adjustwidth}
 
-\section{Installation and Update}
+%\section{Installation and Update}
 
 % NOTE: MacOs and BSD are not supported by this manual yet. You may find additional information regarding 7kaa on these operating systems on the internet. There are BSD ports of 7kaa, and 7kaa is known to install on MacOs.
 
@@ -43,89 +45,70 @@ UDP/IP connection for LAN and Internet play
 
 %Most Gnu/Linux distributions have a package for 7kaa. Use the package manager that comes with your distribution to install and update 7kaa. If your are unable to find the package in your distribution’s repository, try searching for 7kaa.
 
-\textbf{NOTE}: distributions that are not rolling release may have older packages in their stable branch. The official releases from 7kfans.com may be different. Although bugs may appear, the new releases usually have important updates and fixes. 
+%\textbf{NOTE}: distributions that are not rolling release may have older packages in their stable branch. The official releases from 7kfans.com may be different. Although bugs may appear, the new releases usually have important updates and fixes. 
 
 %A Windows 32-bit installer is provided on the download page. It includes the required dependencies to play. 
 % give specifics
 %Follow the prompts that you will see as the installation progresses and choose your options. 
 
-Occasionally, an .exe is released for a development branch on the download page. 
+%Occasionally, an .exe is released for a development branch on the download page. 
 %why?
-Only prebuilt Windows binaries are released via the Downloads page. For a development version on Linux, compile the git snapshot.
+%Only prebuilt Windows binaries are released via the Downloads page. For a development version on Linux, compile the git snapshot.
 
 \section{Building the Game on GNU/Linux}
 
-Make sure you have these installed: 
+Make sure you have these programs installed: 
 
 \begin{adjustwidth}{1cm}{}
 make \\
-autopoint \\
+autoconf \\
 GCC 4.6+ or later (or other C++11 compliant compiler) \\
 git
 \end{adjustwidth}
+
+\clearpage
 	
 Then, install these:
 
 Required dependencies
 
 \begin{adjustwidth}{1cm}{}
-SDL 2.0.2 or later \\
+SDL 2.0.4 or later \\
 enet 1.3.xx \\
-OpenAL-soft or equivalent driver
+OpenAL-soft or equivalent driver \\
+Autoconf 2.65
 \end{adjustwidth}
 
 Optional dependencies
 
 \begin{adjustwidth}{1cm}{}
-Autoconf 2.65 (when using git snapshot.) \\
 libcurl (the URL transfer library, for full 7kfans multiplayer integration) \\
 gettext 0.18 or later \\
 Game music bundle
 \end{adjustwidth}
 
-To begin the process of compiling, download the source code:
+To compile, run:
 
 \begin{lstlisting}[language=bash]
 $ git clone git://www.7kfans.com/7kaa.git
-\end{lstlisting}
-	
-Run the following program in the root folder of the source tree to generate the build configurations: 
-
-\begin{lstlisting}[language=bash]
 $ autogen.sh
-\end{lstlisting}
-	
-Then, run the configure script:
-
-\begin{lstlisting}[language=bash]
 $ ./configure
-\end{lstlisting}
-	
-Compile the source using:
-
-\begin{lstlisting}[language=bash]
 $ make
-\end{lstlisting}
-
-	
-Install the game using:
-
-\begin{lstlisting}[language=bash]
-$ make install
+# make install
 \end{lstlisting}
 
 %\subsection{Compile with Translations}
 
 \subsection{How to Install the Music}
 
-Some packages require manually downloading the music from the download page. To install music, copy music into data folder or use PACKAGE\_DATA\_PATH.
+To install music, copy music into data folder or use PACKAGE\_DATA\_PATH.
 
 From the build directory, run:
 
 \begin{lstlisting}[language=bash]
 $ wget https://www.7kfans.com/downloads/7kaa-music.tar.bz2
 $ bzip2 -cd 7kaa-music.tar.bz2 | tar xvf -
-$ mv 7kaa-music data/ 
+$ mv 7kaa-music/music data/music
 \end{lstlisting}
 
 \section{Troubleshooting}
@@ -140,9 +123,21 @@ Errors during compile & Ensure you have the required dependencies. If you are un
 
 \section{Start up}
 
-\subsection{Git Snapshot}
+In the terminal, make install will allow you to invoke:
 
-To run the game from the build directory, you need to point to the game data folder. The game data folder is set by the environment variable SKDATA. In a bash shell, this can be accomplished by \$ SKDATA=data src/7kaa (where src/7kaa is in the 7kaa directory downloaded via git or in .zip / tar.bz2 form).
+\begin{lstlisting}[language=bash] 
+$ 7kaa
+\end{lstlisting}
+
+%\subsection{Git Snapshot}
+
+To run the game from the build directory, you need to point to the game data folder. The game data folder is set by the environment variable SKDATA. In a bash shell, this can be accomplished by
+
+\begin{lstlisting}[language=bash] 
+$ SKDATA=data src/7kaa 
+\end{lstlisting}
+
+(where src/7kaa is in the 7kaa directory downloaded via git or in .zip / tar.bz2 form).
 
 %\subsection{Windows}
 

--- a/doc/main.tex
+++ b/doc/main.tex
@@ -62,16 +62,20 @@ This manual is distributed in the hope that it will be useful, but WITHOUT ANY W
 
 You should have received a copy of the GNU General Public License along with this manual.  If not, see \href{<http://www.gnu.org/licenses/>}{http://www.gnu.org/licenses/} .
 
-\section{Other Copyright}
+\subsection{Other Copyright}
+
+\subsubsection{Music}
 
 The music is the work of Bjørn Lynne Copyright (c) 1997, and is not provided under the GPL. It may be freely downloaded and used with Seven Kingdoms: Ancient Adversaries, but not modified or repurposed into derivative works. 
 
-\section{Citing the Manual in MLA 8}
+\subsubsection{Trademark}
 
-Whitehouse, Chris, et al. Seven Kingdoms Ancient Adversaries Instruction Manual. Updated by members of the Seven Kingdoms: Ancient Adversaries OSS Project, 2.14.7, Interactive Magic, 1998: Seven Kingdoms: Ancient Adversaries OSS Project, 2018
+Seven Kingdoms is a trademark of Enlight Software Ltd. and the 7kfans project is using the trademark with permission. This license does not constitute a transfer of any ownership, rights, or authority to the trademarks owned by Enlight. Any questions regarding use must be directed to Enlight.
+
+\clearpage
 
 \section{Introduction}
-% 7kaa usage vs \textit{Seven Kingdoms: Ancient Adversaries}
+
 In 2009, Trevor Chan from Enlight Software released the source code for \textit{Seven Kingdoms: Ancient Adversaries}. He released it under a community project so that developers can provide some long awaited bug fixes and address some other game-play issues. The official website for \textit{Seven Kingdoms: Ancient Adversaries} is at \href{<https://7kfans.com/>}{https://7kfans.com/}. Here you will find the \href{<https://www.7kfans.com/forums/>}{\textbf{Forums}}, \href{<https://www.7kfans.com/wiki/index.php/Main_Page>}{\textbf{Wiki}}, and \href{<https://www.7kfans.com/wiki/index.php/Download>}{\textbf{Download Page}}. \textit{Seven Kingdoms: Ancient Adversaries} has been under active development since its 2009 release. If you want to see what has been fixed or changed, see the changelogs for the official releases under \href{<https://7kfans.com/>}{News}. 
 
 This manual is part of the community project. It has been updated to reflect the current status of \textit{Seven Kingdoms: Ancient Adversaries}.

--- a/doc/mouse_keyboard_commands_cheat_codes.tex
+++ b/doc/mouse_keyboard_commands_cheat_codes.tex
@@ -105,11 +105,13 @@
 	\begin{tabular}{ | l | p{6cm} |}
 		\hline	 
 		Action	& Description \\ \hline
-	>	& Next block of text in Training. \\ \hline
-	<	& Previous block of text in Training. \\ \hline
+	\textgreater & Next block of text in Training. \\ \hline
+	\textless	& Previous block of text in Training. \\ \hline
 	Ctrl + (0--9)	& Assign all selected units to a numbered group. \\ \hline
 	Alt + (0--9)	& Select all mobile units previously assigned to a numbered group. \\ \hline
 	Alt + Right-Click	& Manually assign waypoints to mobile unit(s). After setting waypoints, use a normal Right Click to set the final destination. \\ \hline
+	Alt + Enter & Enter or leave windowed mode \\ \hline
+	Alt + g & Screen grab in windowed mode \\ \hline
 	Alt + F4	& Quit to Desktop \\ \hline
 		\hline
 \end{tabular}
@@ -130,7 +132,7 @@ z	& Construct building instantly \\ \hline
 ]	& +20 skill \\ \hline
 ;	& +10 population \\ \hline
 ‘	& +20 spy skill \\ \hline
-\textbackslash\{\}	& Add 1000 food \\ \hline
+\textbackslash & Add 1000 food \\ \hline
 /	& Reveal map \\ \hline
 	\hline
 \end{tabular}

--- a/doc/seats_of_powers_and_greater_beings.tex
+++ b/doc/seats_of_powers_and_greater_beings.tex
@@ -21,6 +21,8 @@
 
 \chapter{Seats of Powers and Greater Beings}
 
+% Please ignore this error, or apply a fix that has the same result 
+
 \begin{center}
 	\\ \textbf{Seats of Power}
 	\\ Chinese Greek Mayan Persian Viking

--- a/doc/starting_new_game.tex
+++ b/doc/starting_new_game.tex
@@ -23,7 +23,7 @@
 
 \section{The Main Menu}
 
-Your entrance to the world of 7kaa begins with starting it.
+Your entrance to the world of \textit{Seven Kingdoms: Ancient Adversaries} begins with starting it.
 
 \begin{wrapfigure}{r}{0.5\textwidth}
 	\begin{center}
@@ -65,9 +65,9 @@ The lesson text will appear at the top of your screen, leaving plenty of space f
 	\includegraphics[width=0.7\linewidth]{Ilesson}
 \end{center}
 
-% fix symbols <>
+% bug here: >Buttons
 
-Page though the lessons by \textbf{Clicking} on the < and > \textbf{Buttons} or do the same by pressing your < and > keys on your keyboard.
+Page though the lessons by \textbf{Clicking} on the \textless and \textgreater \textbf{Buttons} or do the same by pressing your \textless and \textgreater keys on your keyboard.
 
 It is not strictly necessary that you learn your lessons within the designated training scenario. At any time during any Single Player game you may load a Training lesson if you wish to review any aspect of the game.
 
@@ -195,8 +195,8 @@ Even though you have lost, you may continue to observe the progress of the game.
 	\includegraphics[width=0.7\linewidth]{Iload}
 \end{center}
 
-To load a game, Click on its Bar and then Click on the Load Button.
-You may also Double-Click on the Bar.
+To load a game, \textbf{Click} on its Bar and then \textbf{Click} on the \textbf{Load Button}.
+You may also \textbf{Double-Click} on the Bar.
 
 Single Player Games will have the .SAV file extension. multiplayer Games will have the .SVM extension.
 
@@ -214,13 +214,9 @@ Choosing to play a Scenario will take you to a menu similar to the one for choos
 	\includegraphics[width=0.7\linewidth]{Imultiplayer}
 \end{center}
 
-The game supports up to 7 players.
-
 \subsubsection{Initial Setup}
 
-Ensure everyone has the same version of the game. There will be compatibility issues if the game versions are different. Allow the game/program to pass through your firewall. If you have a router, port forwarding might be needed. 2.14.7 uses UDP port 19383 for LAN and 7kfans.com game browsing.
-
-If the application cannot open the default port, it can fall back to a random port assigned by the OS. This should be fine in most cases if this happens on the game host, except if people are connecting via entering the IP address directly (no port entry), or the port in question is the LAN broadcast port (won't be able to see the games)
+All players need the same version of the game, or compatibility issues will arise. Allow \textit{Seven Kingdoms: Ancient Adversaries} to pass through your firewall. If you have a router, port forwarding might be needed. 2.14.7+ uses UDP port 19383 for LAN and 7kfans.com game browsing.
 
 \subsubsection{Lobby }
 
@@ -232,7 +228,7 @@ Beneath your name, you will see the name of the game. You will be able to save o
 
 There will also be two auto-saved games, named AUTO01.SVM and AUTO02.SVM. One of them will have a later date than the other, so you will know which is the most recent.
 
-To load a saved game, Select the name of your save game file and click Load ( everyone must select the same file, "Game Date" must be the same).
+To load a saved game, Select the name of your save game file and \textbf{Click} on Load (everyone must select the same file, "Game Date" must be the same).
 
 \subsubsection{7kfans.com}
 
@@ -242,7 +238,7 @@ If you are setting up the game, \textbf{Click} on the \textbf{Create Button}.
 	\includegraphics[width=0.7\linewidth]{Imultiplayer2}
 \end{center}
 
-If you are not creating this game, a \textbf{Click} on the \textbf{Join Button} will send you to the Available Games page.
+If you are not creating this game, a \textbf{Click} on the \textbf{Join Button} which will send you to the Available Games page.
 
 You will be prompted to enter your forums account username and password. If you have recently logged into the forums, you may leave your password empty.
 
@@ -282,7 +278,7 @@ You can post or search on the Forums to look for other players or set up matches
 	\includegraphics[width=0.7\linewidth]{Iencyclopedia}
 \end{center}
 
-The Encyclopedia includes images and informative descriptions of units and buildings appearing in 7kaa.
+The Encyclopedia includes images and informative descriptions of units and buildings appearing in \textit{Seven Kingdoms: Ancient Adversaries}.
 
 \textbf{Click} on one of the titles in the top section. When you do you will see listed in the bottom section a group of subjects that are under that title.
 
@@ -292,7 +288,7 @@ If you do not \textbf{Click} on anything, the Encyclopedia will present you wi
 
 \subsection{Hall of Fame}
 
-At the end of every game of 7kaa your score will be computed. Your score will take into account the difficulty level at which you were playing and the skill with which you played.
+At the end of every game of \textit{Seven Kingdoms: Ancient Adversaries} your score will be computed. Your score will take into account the difficulty level at which you were playing and the skill with which you played.
 
 If your final score is one of the six highest ever recorded, it will be entered into the Hall of Fame.
 
@@ -322,7 +318,7 @@ You will need to develop a variety of skills to be an effective leader, and to c
 	\vspace{-20pt}
 \end{wrapfigure}
 
-While you are playing a game of 7kaa, you will be able to access various options by \textbf{Clicking} on the \textbf{MENU Button} at the top right of your screen.
+While you are playing a game of \textit{Seven Kingdoms: Ancient Adversaries}, you will be able to access various options by \textbf{Clicking} on the \textbf{MENU Button} at the top right of your screen.
 
 This will bring up the options as seen on the right.
 
@@ -338,7 +334,7 @@ The first choice you will have, which can also be accessed by pressing the O key
 
 Here you can set your Sound Effects and Music volume. Do this by sliding the brass ball left or right until it is in the position that you want.
 
-You may also choose to play any single piece of 7kaa music.
+You may also choose to play any single piece of \textit{Seven Kingdoms: Ancient Adversaries} music.
 
 You can set the detail level of pop-up instructional text that will appear whenever you hold the cursor over a button or icon for a few seconds. You may also turn this feature off, if you prefer.
 
@@ -378,7 +374,7 @@ The game that you are playing will be automatically saved in a separate file aft
 
 \subsection{Retire}
 
-When you decide to retire from a game of 7kaa, the game will end and your score will be calculated.
+When you decide to retire from a game of \textit{Seven Kingdoms: Ancient Adversaries}, the game will end and your score will be calculated.
 
 If you have achieved a high enough score, it will be entered in the Hall of Fame.
 

--- a/doc/villiage.tex
+++ b/doc/villiage.tex
@@ -36,12 +36,12 @@ The number on the lower left shows the total number of people in the selected Vi
 Although there may be up to seven different nationalities in Villages that you will later build, absorb or conquer, in your first Village there will be only one.
 
 The style of houses in Villages will give you a quick idea as to what nationalities are resident there.
-% internal link here
-To see what types of houses belong to which nationalities, see the house images in Chapter 14.
+
+To see what types of houses belong to which nationalities, see the house images in Chapter 16.
 
 Populations in Villages will increase over time up to a maximum of 60. The rate of increase will not be the same for all Villages because Villages which have access to a steady supply of consumer goods will grow faster than those without—higher standards of living induce higher growth rates.
-% internal link here
-See Chapter 20 for Economic Strategy Tips.
+
+See Chapter 22 for Economic Strategy Tips.
 
 \subsection{Peasants}
 
@@ -366,7 +366,10 @@ You may also Grant money to Villagers of other kingdoms if you have a staffed Fo
 
 \textbf{Auto-Granting to a Single Village}: You may automatically Grant funds to your selected Village by first \textbf{Right-Clicking} on the \textbf{Grant Tile} and then \textbf{Clicking} on the Loyalty Level at which you wish to make your Grants.
 
-\textbf{Auto-Granting to All Villages}: By \textbf{Right-Clicking} on one of the numbers you will automatically Grant money to every one of your Villages when their average Loyalty Level drops to the selected level.
+% BUG HERE
+
+\textbf{Auto-Granting to All Villages}: By
+\textbf{Right-Clicking} on one of the numbers you will automatically Grant money to every one of your Villages when their average Loyalty Level drops to the selected level.
 
 \clearpage
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-09 15:18-0700\n"
-"PO-Revision-Date: 2018-08-17 10:53-0500\n"
+"POT-Creation-Date: 2018-09-09 15:39-0700\n"
+"PO-Revision-Date: 2018-09-13 12:36-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ru\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"X-Generator: Poedit 2.0.9\n"
+"X-Generator: Poedit 2.1.1\n"
 
 #: src/AM.cpp:342 src/AM.cpp:354
 msgid "You cannot specify multiple -host or -join options."
@@ -194,28 +194,25 @@ msgstr "Бой"
 #: src/OR_TECH.cpp:152 src/OR_TRADE.cpp:86 src/OR_TRADE.cpp:117
 #: src/OU_MARIF.cpp:521
 msgid "Hit Points"
-msgstr "Здоровье"
+msgstr "здоровье"
 
 #: src/OFIRMIF2.cpp:94 src/OTOWNIF.cpp:1262
 msgid "Spy Skill"
-msgstr "Шпионские навыки"
+msgstr "навыки"
 
 #: src/OFIRMIF2.cpp:96 src/OR_SPY.cpp:78 src/OTOWNIF.cpp:1264
 msgid "Action"
 msgstr "Действие"
 
 #: src/OFIRMIF3.cpp:88
-#, fuzzy
 msgid "Bribe"
-msgstr "Взятки"
+msgstr "Взятка"
 
 #: src/OFIRMIF3.cpp:116
-#, fuzzy
 msgid "Bribe Succeeded."
 msgstr "Подкуп удался."
 
 #: src/OFIRMIF3.cpp:122
-#, fuzzy
 msgid "Bribe Failed."
 msgstr "Подкуп провалился."
 
@@ -233,7 +230,7 @@ msgstr "И казнен."
 #: src/OFIRMIF3.cpp:247
 #, c-format
 msgid "Offer %s"
-msgstr "Предложить  %s"
+msgstr "Предложить %s"
 
 #: src/OFIRMIF3.cpp:545 src/OFIRMIF3.cpp:560
 msgid "Assassination Succeeded."
@@ -260,13 +257,12 @@ msgstr "Лидерство"
 #: src/OF_FACT.cpp:371
 #, c-format
 msgid "Producing %s Products"
-msgstr "Производится %s продуктов"
+msgstr "%s продуктов"
 
 # data/resource/help.res:78
 #: src/OF_FACT.cpp:383 src/OF_MINE.cpp:287
-#, fuzzy
 msgid "Monthly Production"
-msgstr "Сменить профиль производства"
+msgstr "Ежемесячное про-во"
 
 # #-#-#-#-#  7kaa.res.pot  #-#-#-#-#
 # data/resource/help.res:313
@@ -278,7 +274,7 @@ msgstr "Запасы сырья"
 # data/resource/help.res:317
 #: src/OF_FACT.cpp:396
 msgid "Product Stock"
-msgstr "Количество на складе"
+msgstr "Кол-во продуктов"
 
 #: src/OF_HARB.cpp:453 src/OU_MARIF.cpp:87
 msgid "Units"
@@ -352,11 +348,11 @@ msgstr "Добывается %s"
 # data/resource/help.res:341
 #: src/OF_MINE.cpp:294
 msgid "Mined Stock"
-msgstr "Промежуточный запас"
+msgstr "Промеж. запас"
 
 #: src/OF_MINE.cpp:297
 msgid "Untapped Reserve"
-msgstr "Неограниченный запас"
+msgstr "Неогр. запас"
 
 #. TRANSLATORS: <Fryhtan Type> Lair
 #: src/OF_MONS.cpp:137
@@ -428,9 +424,8 @@ msgid "Username:"
 msgstr "Логин:"
 
 #: src/OGAMEMP.cpp:1463
-#, fuzzy
 msgid "Unable to connect to 7kfans.com."
-msgstr "Невозможно соединиться из гостевой."
+msgstr "нет соединения с 7kfans.com."
 
 #: src/OGAMEMP.cpp:1947
 msgid "Unable to communicate with the network"
@@ -477,7 +472,7 @@ msgstr "Загружается таблица лидеров"
 
 #: src/OGAMEMP.cpp:2956 src/OGAMEMP.cpp:4863
 msgid "?anonymous?"
-msgstr "?anonymous?"
+msgstr "?аноним?"
 
 #: src/OGAMEMP.cpp:3029 src/OGAMEMP.cpp:4937
 msgid "The game host has disconnected."
@@ -599,17 +594,17 @@ msgstr "Нет"
 
 #: src/OGAMEND.cpp:264
 msgid "All Fryhtans have been Destroyed !"
-msgstr "Все Фрихтаны были уничтожены!"
+msgstr "Все Фрихтаны были уничтожены !"
 
 #: src/OGAMEND.cpp:267
 msgid "Your Kingdom has Achieved the Highest Fryhtan Battling Score !"
-msgstr "Ваше королевство достигло наивысших боевых очков Фрихтанов!"
+msgstr "Ваше королевство достигло наивысших боевых очков Фрихтанов !"
 
 #. TRANSLATORS: <King's Kingdom> has Achieved the Highest Fryhtan Battling Score !
 #: src/OGAMEND.cpp:272
 #, c-format
 msgid "%s has Achieved the Highest Fryhtan Battling Score !"
-msgstr "%s has Achieved the Highest Fryhtan Battling Score !"
+msgstr "%s достигло наивысших боевых очков Фрихтанов ! "
 
 #. TRANSLATORS: Part of "Your Kingdom has Reached its Population/Economic Score/Total Score Goal of <Number> !"
 #: src/OGAMEND.cpp:283 src/OGAMEND.cpp:301 src/OGAMEND.cpp:319
@@ -638,21 +633,21 @@ msgstr "целевой отметки очков экономики %s !"
 #: src/OGAMEND.cpp:327
 #, c-format
 msgid "its Total Score Goal of %s !"
-msgstr "целевой отметки игровых очков  %s !"
+msgstr "целевой отметки игровых очков %s !"
 
 #: src/OGAMEND.cpp:336
 msgid "Your Kingdom has Defeated All Other Kingdoms !"
-msgstr "Ваше королевство одержало победу над другими королевствами!"
+msgstr "Ваше королевство одержало победу над другими королевствами !"
 
 #. TRANSLATORS: <King's Kingdom> has Defeated All Other Kingdoms !
 #: src/OGAMEND.cpp:341
 #, c-format
 msgid "%s has Defeated All Other Kingdoms !"
-msgstr "%s одержал победу над другими королевствами!"
+msgstr "%s одержал победу над другими королевствами !"
 
 #: src/OGAMEND.cpp:351
 msgid "You Have Lost the Game !"
-msgstr "Вы проиграли!"
+msgstr "Вы проиграли !"
 
 #. TRANSLATORS: You Surrendered to <King's Kingdom> on <Date>.
 #: src/OGAMEND.cpp:370
@@ -667,7 +662,7 @@ msgstr ""
 
 #: src/OGAMEND.cpp:381
 msgid "Your Kingdom has Gone Down to Ignominious Defeat !"
-msgstr "Ваше королевство постигло бесславное поражение!"
+msgstr "Ваше королевство постигло бесславное поражение !"
 
 #. TRANSLATORS: You Retired on <Date>.
 #: src/OGAMEND.cpp:396
@@ -724,7 +719,6 @@ msgid "King's Buildings Cleared"
 msgstr "Королевские строения зачищены"
 
 #: src/OGAMEND.cpp:429
-#, fuzzy
 msgid "Enemy Civilians Collaterally Damaged"
 msgstr "Гражданские противника понесли ущерб"
 
@@ -742,18 +736,16 @@ msgid "Population"
 msgstr "Население"
 
 #: src/OGAMEND.cpp:465 src/OR_RANK.cpp:84 src/OSPYA.cpp:45
-#, fuzzy
 msgid "Military"
-msgstr "Очки военного дела"
+msgstr "Армия"
 
 #: src/OGAMEND.cpp:466 src/OR_RANK.cpp:85 src/OSPYA.cpp:45
 msgid "Economy"
 msgstr "Экономика"
 
 #: src/OGAMEND.cpp:467 src/OR_NAT.cpp:131 src/OR_RANK.cpp:86
-#, fuzzy
 msgid "Reputation"
-msgstr "Очки репутации"
+msgstr "Репутация"
 
 #. TRANSLATORS: Part of "Fryhtan Battling"
 #: src/OGAMEND.cpp:474 src/OR_RANK.cpp:88
@@ -763,7 +755,7 @@ msgstr "Фрихтан"
 #. TRANSLATORS: Part of "Fryhtan Battling"
 #: src/OGAMEND.cpp:476 src/OR_RANK.cpp:90
 msgid "Battling"
-msgstr "Воинственность"
+msgstr "агрессия"
 
 #: src/OGAMEND.cpp:524 src/OR_RANK.cpp:135
 msgid "Population Score"
@@ -771,7 +763,7 @@ msgstr "Очки населения"
 
 #: src/OGAMEND.cpp:524 src/OR_RANK.cpp:135
 msgid "Military Score"
-msgstr "Очки военного дела"
+msgstr "Очки армии"
 
 #: src/OGAMEND.cpp:524 src/OR_RANK.cpp:135
 msgid "Economic Score"
@@ -799,7 +791,7 @@ msgstr "Финальный счет:  %s X "
 #: src/OGAMEND.cpp:565 src/OR_RANK.cpp:178
 #, c-format
 msgid "%s (Difficulty Rating)"
-msgstr "%s (Коэффициент сложности)"
+msgstr "%s (Коэф. сложности)"
 
 #. TRANSLATORS: +  <Number> (Bonus)  =  <Number>
 #: src/OGAMEND.cpp:580
@@ -817,7 +809,7 @@ msgstr "Очки : "
 
 #: src/OGAMHALL.cpp:285
 msgid "Period : "
-msgstr "Длительность : "
+msgstr "Время : "
 
 #: src/OGAMHALL.cpp:294 src/OGAMSCE2.cpp:410
 msgid "Difficulty : "
@@ -850,9 +842,8 @@ msgid "Error writing saved game data."
 msgstr "Ошибка записи данных сохранения."
 
 #: src/OGFILE.cpp:104
-#, fuzzy
 msgid "The game is not saved."
-msgstr " Игра не сохранена."
+msgstr "Игра не сохранена."
 
 #: src/OGFILE.cpp:126
 msgid "Cannot open save game file"
@@ -974,17 +965,17 @@ msgstr "Война"
 #. TRANSLATORS: Part of "Duration of Tense Status"
 #: src/ONATIONB.cpp:58
 msgid "Tense"
-msgstr "Напряженный"
+msgstr "Напряжен"
 
 #. TRANSLATORS: Part of "Duration of Neutral Status"
 #: src/ONATIONB.cpp:60
 msgid "Neutral"
-msgstr "Нейтральный"
+msgstr "Нейтраль"
 
 #. TRANSLATORS: Part of "Duration of Friendly Status"
 #: src/ONATIONB.cpp:62
 msgid "Friendly"
-msgstr "Дружественный"
+msgstr "Друг"
 
 #. TRANSLATORS: Par of "Duration of Alliance Status"
 #: src/ONATIONB.cpp:64
@@ -1116,7 +1107,7 @@ msgstr[2] "%d %s %s эмигрировали из %s в вашу деревню 
 #, c-format
 msgid "%d %s Peasant has immigrated from %s to your village of %s."
 msgid_plural "%d %s Peasants have immigrated from %s to your village of %s."
-msgstr[0] "%d %s крестьянин эмигрировал из %s  в вашу деревню %s."
+msgstr[0] "%d %s крестьянин эмигрировал из %s в вашу деревню %s."
 msgstr[1] "%d %s крестьян эмигрировали из %s в вашу деревню %s."
 msgstr[2] "%d %s крестьян эмигрировали из %s в вашу деревню %s."
 
@@ -1405,9 +1396,8 @@ msgid "Your general, %s, has been assassinated by an enemy spy."
 msgstr "Ваш Генерал, %s, был убит шпионом противника."
 
 #: src/ONEWSENG.cpp:1003
-#, fuzzy
 msgid "The enemy spy has been killed."
-msgstr " Шпион противника был убит."
+msgstr "Шпион противника был убит."
 
 #: src/ONEWSENG.cpp:1023
 msgid "An enemy spy has been killed while attempting to assassinate your King."
@@ -1699,9 +1689,8 @@ msgid "Recovered Treasure"
 msgstr "Добытые сокровища"
 
 #: src/OR_ECO.cpp:205
-#, fuzzy
 msgid "Worker Income"
-msgstr "Плата рабочим"
+msgstr "доход рабочим"
 
 #: src/OR_ECO.cpp:206
 msgid "Sale of Buildings"
@@ -1712,49 +1701,48 @@ msgid "Aid/Tribute from Other Kingdoms"
 msgstr "Помощь/Дань от других королевств"
 
 #: src/OR_ECO.cpp:208
-#, fuzzy
 msgid "Cheating"
 msgstr "Читерство"
 
 #: src/OR_ECO.cpp:232
 msgid "General Costs"
-msgstr "Общая стоимость"
+msgstr "стоимость Генералей"
 
 #: src/OR_ECO.cpp:233
 msgid "Spy Costs"
-msgstr "На шпионов"
+msgstr "стоимость шпионов"
 
 #: src/OR_ECO.cpp:234
 msgid "Other Mobile Human Unit Costs"
-msgstr "На другие передвижные отряды людей"
+msgstr "Стоимость других передвижных отрядов людей"
 
 #: src/OR_ECO.cpp:235
 msgid "Caravan Costs"
-msgstr "На караваны"
+msgstr "стоимость караванов"
 
 #: src/OR_ECO.cpp:236
 msgid "Weapons Costs"
-msgstr "На вооружение"
+msgstr "стоимость оружия"
 
 #: src/OR_ECO.cpp:237
 msgid "Ship Costs"
-msgstr "На корабли"
+msgstr "стоимость кораблей"
 
 #: src/OR_ECO.cpp:238
 msgid "Buildings Costs"
-msgstr "На постройки"
+msgstr "стоимость постройки"
 
 #: src/OR_ECO.cpp:239
 msgid "Training Units"
-msgstr "Тренировка"
+msgstr "Тренировка отрядов"
 
 #: src/OR_ECO.cpp:240
 msgid "Hiring Units"
-msgstr "На наем отрядов"
+msgstr "Наём отрядов"
 
 #: src/OR_ECO.cpp:241
 msgid "Honoring Units"
-msgstr "На награды отрядам"
+msgstr "Награждение отрядов"
 
 #: src/OR_ECO.cpp:242
 msgid "Foreign Worker Salaries"
@@ -1786,9 +1774,8 @@ msgstr "Командор"
 
 #. TRANSLATORS: Part of "Commanded Soldiers"
 #: src/OR_MIL.cpp:99
-#, fuzzy
 msgid "Commanded"
-msgstr "Под командованием"
+msgstr "под комвнд."
 
 #. TRANSLATORS: Part of "Commanded Soldiers"
 #: src/OR_MIL.cpp:101
@@ -1801,7 +1788,7 @@ msgstr "Статус"
 
 #: src/OR_MIL.cpp:127
 msgid "Unit Type"
-msgstr "Тип отряда"
+msgstr "Тип юнита"
 
 #: src/OR_MIL.cpp:128
 msgid "No. of Units"
@@ -1828,7 +1815,6 @@ msgid "Total Units: %s"
 msgstr "Итого отрядов: %s"
 
 #: src/OR_MIL.cpp:376
-#, fuzzy
 msgid "In Fort"
 msgstr "В форте"
 
@@ -1841,9 +1827,8 @@ msgid "On Ship"
 msgstr "На корабле"
 
 #: src/OR_MIL.cpp:390 src/OR_SPY.cpp:270
-#, fuzzy
 msgid "Mobile"
-msgstr "В пути"
+msgstr "в походе"
 
 #: src/OR_MIL.cpp:468
 msgid "Human General"
@@ -1948,7 +1933,7 @@ msgstr "Продолжительность %s"
 #: src/OR_NAT.cpp:546
 #, c-format
 msgid "Allow Your Units to Attack %s's Kingdom"
-msgstr "Позволить вашим отрядам атаковать королевство %s"
+msgstr "Позволить вашим отрядам атаковать %s"
 
 #. TRANSLATORS: <King>'s Kingdom's Treasure
 #: src/OR_NAT.cpp:561
@@ -1966,7 +1951,7 @@ msgstr "Еда королевства %s"
 #: src/OR_NAT.cpp:583
 #, c-format
 msgid "%s's Kingdom's Diplomatic Status with Other Kingdoms:"
-msgstr "Дипломатическое состояние королевства %s с другими королевствами :"
+msgstr "Дипломатическое состояние королевства %s с другими королевствами:"
 
 #: src/OR_NAT.cpp:606
 msgid "Trade Treaty"
@@ -2049,9 +2034,8 @@ msgid "Spy Name"
 msgstr "Имя шпиона"
 
 #: src/OR_SPY.cpp:74
-#, fuzzy
 msgid "Cloak"
-msgstr "Прикрытие"
+msgstr "плащ"
 
 #: src/OR_SPY.cpp:75
 msgid "Location"
@@ -2082,7 +2066,7 @@ msgstr "Исследуется"
 
 #: src/OR_TECH.cpp:119
 msgid "Research Progress"
-msgstr "Прогресс исследования"
+msgstr "Прогресс"
 
 #. TRANSLATORS: Part of "Tower of Science"
 #: src/OR_TECH.cpp:122
@@ -2128,7 +2112,7 @@ msgstr "Здание"
 
 #: src/OR_TOWN.cpp:113
 msgid "Unit Cost"
-msgstr "Стоимость отряда"
+msgstr "Стоимость юнита"
 
 #: src/OR_TOWN.cpp:117
 msgid "No. of Structures"
@@ -2170,19 +2154,19 @@ msgstr "Караван"
 
 #: src/OR_TRADE.cpp:88 src/OR_TRADE.cpp:119
 msgid "Stop 1"
-msgstr "Остановка 1"
+msgstr "один"
 
 #: src/OR_TRADE.cpp:89 src/OR_TRADE.cpp:120
 msgid "Stop 2"
-msgstr "Остановка 2"
+msgstr "два"
 
 #: src/OR_TRADE.cpp:90 src/OR_TRADE.cpp:121
 msgid "Stop 3"
-msgstr "Остановка 3"
+msgstr "три"
 
 #: src/OR_TRADE.cpp:91 src/OR_TRADE.cpp:122
 msgid "Goods Carried"
-msgstr "Товары/груз перенесены"
+msgstr "Товары перенесены"
 
 #: src/OR_TRADE.cpp:113
 msgid "Ship"
@@ -2216,7 +2200,7 @@ msgstr "Скролить Силу"
 
 #: src/OSITEDRW.cpp:67
 msgid "Nationality"
-msgstr "Национальность"
+msgstr "Раса"
 
 #: src/OSITEDRW.cpp:68
 msgid "Invoke"
@@ -2227,34 +2211,30 @@ msgid "Treasure"
 msgstr "Сокровища"
 
 #: src/OSITEDRW.cpp:80
-#, fuzzy
 msgid "Worth"
-msgstr "Цена/Сумма"
+msgstr "Сумма"
 
 #: src/OSKILL.cpp:34
-#, fuzzy
 msgid "Construction"
-msgstr "Строится/Строительство"
+msgstr "Строительство"
 
 #: src/OSKILL.cpp:36
 msgid "Mining"
-msgstr "Горная промышленность"
+msgstr "Горная пром."
 
 #: src/OSKILL.cpp:37
 msgid "Manufacture"
 msgstr "Производство"
 
 #: src/OSKILL.cpp:38
-#, fuzzy
 msgid "Research"
-msgstr "Исследуется"
+msgstr "Исследство"
 
 #: src/OSKILL.cpp:39 src/OUNITIF.cpp:1165
 msgid "Spying"
-msgstr "Слежка"
+msgstr "шпионство"
 
 #: src/OSKILL.cpp:40
-#, fuzzy
 msgid "Praying"
 msgstr "Моление"
 
@@ -2268,7 +2248,7 @@ msgstr "Сон"
 
 #: src/OSPY.cpp:598
 msgid "Sow Dissent"
-msgstr "Подстрекать неверующих"
+msgstr "Посеять раздор"
 
 #: src/OSPY.cpp:601
 msgid "Sabotage"
@@ -2283,15 +2263,13 @@ msgid "Villages"
 msgstr "Деревни"
 
 #: src/OSPYA.cpp:45
-#, fuzzy
 msgid "Trade"
 msgstr "Торговля"
 
 # data/resource/help.res:26
 #: src/OSPYA.cpp:45
-#, fuzzy
 msgid "Espionage"
-msgstr "Отчет о шпионаже"
+msgstr "шпионаж"
 
 #: src/OSPYA.cpp:328
 msgid "Steal which type of secrets?"
@@ -2303,7 +2281,7 @@ msgstr "Невозможно определить местоположение �
 
 #. TRANSLATORS: Waiting for <King's Kingdom>
 #: src/OSYS.cpp:860
-#, fuzzy, c-format
+#, c-format
 msgid "Waiting for %s"
 msgstr "Ожидается %s"
 
@@ -2332,7 +2310,6 @@ msgid "Your king is now immortal."
 msgstr "Теперь Ваш король бессмертен."
 
 #: src/OSYS.cpp:1840
-#, fuzzy
 msgid "King immortal mode is now disabled."
 msgstr "Бессмертие короля более недоступно."
 
@@ -2350,7 +2327,6 @@ msgid "The current screen has been written to file %s."
 msgstr "Текущий файл был записан в файл %s."
 
 #: src/OSYS.cpp:2671
-#, fuzzy
 msgid "Failed Loading Game"
 msgstr "Ошибка загрузки"
 
@@ -2371,7 +2347,6 @@ msgid "You haven't saved any games yet."
 msgstr "У Вас нет сохранённых игр."
 
 #: src/OSaveGameArray.cpp:386
-#, fuzzy
 msgid "Empty Game Slot"
 msgstr "Пустая ячейка"
 
@@ -2385,21 +2360,19 @@ msgstr "Время игры: "
 
 #: src/OSaveGameArray.cpp:623
 msgid "File Name: "
-msgstr "Название файла: "
+msgstr "имя файла: "
 
 #: src/OSaveGameArray.cpp:649
 msgid "File Date: "
 msgstr "Время файла: "
 
 #: src/OSaveGameArray.cpp:687
-#, fuzzy
 msgid "It will overwrite the existing saved game. Proceed?"
-msgstr "Данная игра будет перезаписана, продолжить?"
+msgstr "Данная игра будет перезаписана. продолжить?"
 
 #: src/OSaveGameArray.cpp:889
-#, fuzzy
 msgid "This saved game will be deleted. Proceed?"
-msgstr "Эта игра будет удалена, продолжить?"
+msgstr "Эта игра будет удалена. продолжить?"
 
 #: src/OSaveGameProvider.cpp:136
 msgid "Path too long to the saved game."
@@ -2443,7 +2416,7 @@ msgstr "%s предлагает Вам дружеское соглашение."
 #: src/OTALKENG.cpp:213
 #, c-format
 msgid "%s proposes an alliance treaty to you."
-msgstr "%s предлагает Вам военное соглашение."
+msgstr "%s предлагает Вам союзное соглашение."
 
 #. TRANSLATORS: <King's Kingdom> accepts your proposed trade treaty.
 #: src/OTALKENG.cpp:226
@@ -2557,7 +2530,7 @@ msgstr "%s прекращает с вами договор о союзе."
 #: src/OTALKENG.cpp:379
 #, c-format
 msgid "You request a cease-fire with %s."
-msgstr "Вы запрашиваете перемирие с%s."
+msgstr "Вы запрашиваете перемирие с %s."
 
 #. TRANSLATORS: <King's Kingdom> requests a cease-fire.
 #: src/OTALKENG.cpp:384
@@ -2593,7 +2566,7 @@ msgstr "Вы отказываетесь от прекращения огня с 
 #: src/OTALKENG.cpp:435
 #, c-format
 msgid "You request %s to declare war on %s%s."
-msgstr "Вы просите%s объявить войну %s%s."
+msgstr "Вы просите %s объявить войну %s%s."
 
 #. TRANSLATORS: <King 1's Kingdom> requests that you declare war on <King 2's Kingdom><Kingdom color>.
 #: src/OTALKENG.cpp:440
@@ -2773,7 +2746,7 @@ msgstr "%s запрашивает %s в помощи от вас."
 #: src/OTALKENG.cpp:736
 #, c-format
 msgid "%s demands %s in tribute from you."
-msgstr "%s требует от вас %s."
+msgstr "%s требует в подаче от вас %s."
 
 #. TRANSLATORS: <King's Kingdom> agrees to give you <Amount> in aid.
 #: src/OTALKENG.cpp:748
@@ -2947,39 +2920,39 @@ msgstr "Вы отказываетесь посылать военную помо
 #: src/OTALKENG.cpp:1043
 #, c-format
 msgid "You request %s to join an embargo on trade with %s%s."
-msgstr "Вы просите %s присоединиться к эмбарго на торговлю с %s %s."
+msgstr "Вы просите %s присоединиться к эмбарго на торговлю с %s%s."
 
 #. TRANSLATORS: <King 1's Kingdom> requests you to join an embargo on trade with <King 2's Kingdom><Kingdom color>.
 #: src/OTALKENG.cpp:1048
 #, c-format
 msgid "%s requests you to join an embargo on trade with %s%s."
-msgstr "%s просит присоединиться к эмбарго на торговлю с %s %s."
+msgstr "%s просит присоединиться к эмбарго на торговлю с %s%s."
 
 #. TRANSLATORS: <King 1's Kingdom> agrees to join an embargo on trade with <King 2's Kingdom><Kingdom color>.
 #: src/OTALKENG.cpp:1057
 #, c-format
 msgid "%s agrees to join an embargo on trade with %s%s."
-msgstr "%s соглашается присоединиться к эмбарго на торговлю с %s %s."
+msgstr "%s соглашается присоединиться к эмбарго на торговлю с %s%s."
 
 #. TRANSLATORS: <King 1's Kingdom> refuses to join an embargo on trade with <King 2's Kingdom><Kingdom color>.
 #: src/OTALKENG.cpp:1060
 #, c-format
 msgid "%s refuses to join an embargo on trade with %s%s."
-msgstr "%s отказывается присоединиться к эмбарго на торговлю с %s %s."
+msgstr "%s отказывается присоединиться к эмбарго на торговлю с %s%s."
 
 #. TRANSLATORS: You agree to join an embargo on trade with <King 1's Kingdom><Kingdom color> as requested by <King 2's Kingdom>.
 #: src/OTALKENG.cpp:1066
 #, c-format
 msgid "You agree to join an embargo on trade with %s%s as requested by %s."
 msgstr ""
-"Вы соглашаетесь присоединиться к эмбарго на торговлю с %s %s по запросу %s."
+"Вы соглашаетесь присоединиться к эмбарго на торговлю с %s%s по запросу %s."
 
 #. TRANSLATORS: You refuse to join an embargo on trade with <King 1's Kingdom><Kingdom color> as requested by <King 2's Kingdom>.
 #: src/OTALKENG.cpp:1069
 #, c-format
 msgid "You refuse to join an embargo on trade with %s%s as requested by %s."
 msgstr ""
-"Вы отказываетесь присоединиться к эмбарго на торговлю с %s %s по запросу %s."
+"Вы отказываетесь присоединиться к эмбарго на торговлю с %s%s по запросу %s."
 
 #. TRANSLATORS: You offer <Amount> for the throne of <King's Kingdom>.
 #: src/OTALKENG.cpp:1108
@@ -3030,7 +3003,7 @@ msgstr "Сообщение отправлено."
 
 #: src/OTALKRES.cpp:163
 msgid "How much tribute?"
-msgstr "Сколько Вы предлагаете?"
+msgstr "Сколько дани?"
 
 #: src/OTALKRES.cpp:170
 msgid "How much aid?"
@@ -3050,7 +3023,7 @@ msgstr "Предложить дружественное соглашение."
 
 #: src/OTALKRES.cpp:206
 msgid "Propose an alliance treaty."
-msgstr "Предложить военный союз."
+msgstr "Предложить союз соглашение."
 
 #: src/OTALKRES.cpp:207
 msgid "Terminate our trade treaty."
@@ -3062,7 +3035,7 @@ msgstr "Расторгнуть наше дружественное соглаш�
 
 #: src/OTALKRES.cpp:209
 msgid "Terminate our alliance treaty."
-msgstr "Расторгнуть наше военное соглашение."
+msgstr "Расторгнуть наше союзное соглашение."
 
 #: src/OTALKRES.cpp:210
 msgid "Request immediate military aid."
@@ -3133,7 +3106,6 @@ msgid "How much food do you want to purchase?"
 msgstr "Сколько продовольствия Вы хотите закупить?"
 
 #: src/OTALKRES.cpp:364
-#, fuzzy
 msgid "How much do you offer for 10 units of food?"
 msgstr "Сколько Вы предложите за 10 единиц продовольствия?"
 
@@ -3143,7 +3115,7 @@ msgstr "Какую технолонию?"
 
 #: src/OTALKRES.cpp:440
 msgid "Which version?"
-msgstr "Какой вариант?"
+msgstr "Какую вариантю?"
 
 #: src/OTALKRES.cpp:466
 msgid "How much do you offer?"
@@ -3159,7 +3131,6 @@ msgid "Confirm."
 msgstr "Подтвердить."
 
 #: src/OTALKRES.cpp:901
-#, fuzzy
 msgid ""
 "You've sent too many messages to this kingdom. You cannot send any new "
 "messages until the existing ones are processed."
@@ -3168,9 +3139,8 @@ msgstr ""
 "посылать сообщения, пока не будут обработаны ранние."
 
 #: src/OTALKRES.cpp:1090
-#, fuzzy
 msgid "Continue"
-msgstr "Контрибуция"
+msgstr "Продолжать"
 
 #: src/OTALKRES.cpp:1339
 msgid "Accept."
@@ -3186,7 +3156,7 @@ msgstr "Сопротивление"
 
 #: src/OTOWNIF.cpp:291
 msgid "Avg"
-msgstr "Среднее значение"
+msgstr "С/з"
 
 #: src/OTOWNIF.cpp:325
 msgid "Controlled by Rebels"
@@ -3203,21 +3173,18 @@ msgstr "Производство"
 #: src/OTOWNIF.cpp:1098
 msgid "Automatically Collect Tax from Villagers when their Loyalty reaches:"
 msgstr ""
-"Автоматически осуществлять сбор налога с жителей, когда их преданность "
-"достигнет:"
+"Автоматически осуществлять сбор налога, когда их преданность достигнет:"
 
 #: src/OTOWNIF.cpp:1100
 msgid "Automatically Grant Money to Villagers when their Loyalty drops below:"
-msgstr ""
-"Автоматически выделять деньги населению, когда их лояльность падает ниже:"
+msgstr "Автоматически выделять, когда их лояльность падает ниже:"
 
 #: src/OTOWNIF.cpp:1102
 msgid ""
 "(Left-click below to apply to this village. Right-click below to apply to "
 "all your villages.)"
 msgstr ""
-"(Щелкните левой кнопкой мыши, чтобы применить к данной деревне. Щелкните "
-"правой кнопкой мыши, чтобы применить ко всем Вашим деревням.)"
+"(Левый щелчек для данной деревни. Правый щелчек для всех ваших деревней.)"
 
 #: src/OTOWNIF.cpp:1115
 msgid "Disabled"
@@ -3225,7 +3192,7 @@ msgstr "Недоступно"
 
 #: src/OTUTOR.cpp:481
 msgid "Next Training"
-msgstr "Следующая тренировка"
+msgstr "Следующ"
 
 #: src/OTUTOR.cpp:482
 msgid "Quit Training"
@@ -3237,7 +3204,7 @@ msgstr "Учебные материалы не найдены."
 
 #: src/OUNIT.cpp:752 src/OUNITIF.cpp:1211
 msgid "Rebel Leader"
-msgstr "Предводитель мятежников"
+msgstr "Лидер мятежников"
 
 #: src/OUNIT.cpp:765 src/OUNITIF.cpp:1213
 msgid "General"
@@ -3247,7 +3214,7 @@ msgstr "Генерал"
 #: src/OUNITIF.cpp:1015
 #, c-format
 msgid "Please select a location to build the %s."
-msgstr "Пожалуйста, выберите место, чтобы построить %s."
+msgstr "выберите место, чтобы построить %s."
 
 #: src/OUNITIF.cpp:1055
 msgid "Please select a location to settle."
@@ -3304,12 +3271,12 @@ msgstr "Ближайшие враги"
 
 #: src/OUNITIF.cpp:1363
 msgid "Spy Cloak:"
-msgstr "Шпионский плащ:"
+msgstr "плащ:"
 
 #: src/OU_CARA.cpp:158 src/OU_CARA.cpp:179 src/OU_MARIF.cpp:610
 #: src/OU_MARIF.cpp:630
 msgid "Set Stop"
-msgstr "Задать остановку"
+msgstr "Задать стопу"
 
 #: src/OU_CARA.cpp:174 src/OU_MARIF.cpp:625
 msgid "Pick up: "
@@ -3317,7 +3284,7 @@ msgstr "Подобрать: "
 
 #: src/OU_CARA.cpp:187 src/OU_MARIF.cpp:638
 msgid "View Stop"
-msgstr "Просмотр остановки"
+msgstr "Просмотр"
 
 #: src/OU_MONS.cpp:65
 #, c-format
@@ -3387,7 +3354,6 @@ msgid "Ballista"
 msgstr "Баллиста"
 
 # data/resource/std/00005-UNIT.dbf
-#, fuzzy
 msgid "Broosken"
 msgstr "Брускен"
 
@@ -3411,9 +3377,8 @@ msgid "Chinese"
 msgstr "Китаец"
 
 # data/resource/std/00005-UNIT.dbf
-#, fuzzy
 msgid "Deezboanz"
-msgstr "Дизбонс"
+msgstr "Дизбонз"
 
 # data/resource/std/00005-UNIT.dbf
 msgid "Djini"
@@ -3428,7 +3393,6 @@ msgid "Dragon"
 msgstr "Дракон"
 
 # data/resource/std/00005-UNIT.dbf
-#, fuzzy
 msgid "Droog"
 msgstr "Друк"
 
@@ -3451,17 +3415,16 @@ msgid "Greek"
 msgstr "Грек"
 
 # data/resource/std/00005-UNIT.dbf
-#, fuzzy
 msgid "Haubudam"
-msgstr "Хабудам (Габудам)"
+msgstr "Хабудам"
 
 # data/resource/std/00005-UNIT.dbf
 msgid "Holgh"
-msgstr "Холг (Голг)"
+msgstr "Холг"
 
 # data/resource/std/00005-UNIT.dbf
 msgid "Ick"
-msgstr "Мерзкий монстр"
+msgstr "Ик"
 
 # data/resource/std/00005-UNIT.dbf
 msgid "Isis"
@@ -3476,7 +3439,7 @@ msgstr "Японец"
 
 # data/resource/std/00005-UNIT.dbf
 msgid "Jing Nung"
-msgstr "Цинг Нунг/Джинг Нунг"
+msgstr "Джинг Нунг"
 
 # data/resource/std/00005-UNIT.dbf
 msgid "Karrotten"
@@ -3524,7 +3487,7 @@ msgstr "Перс"
 
 # data/resource/std/00005-UNIT.dbf
 msgid "Pfith"
-msgstr "Пфиф"
+msgstr "Пиф"
 
 # data/resource/std/00005-UNIT.dbf
 msgid "Phoenix"
@@ -3586,7 +3549,7 @@ msgstr "Зулу"
 
 # data/resource/std/00005-UNIT.dbf
 msgid "uNkulunkulu"
-msgstr "uNkulunkulu"
+msgstr "ункулункулу"
 
 # data/resource/std/00006-RACE.dbf
 msgid "Mayan"
@@ -3673,7 +3636,7 @@ msgstr ""
 "далекими королевствами или для соединения отдаленных частей вашей империи. "
 "Вы также узнаете, как устанавливать порты захода и как управлять грузом для "
 "своих кораблей, а также как переключаться между режимом автоматической "
-"торговли и режимом управления. "
+"торговли и управления"
 
 # data/resource/tut_intr/00003-8FRYHTAN.txt:1
 msgid ""
@@ -3698,7 +3661,7 @@ msgstr ""
 "В этом уроке вы научитесь использовать свое исследование оружия путем "
 "строительства военных заводов и производства оружия. Вы также узнаете, как "
 "управлять этим оружием в поле и как максимизировать его эффективность. "
-"Особое внимание будет уделено самому необычному оружию, Поркупайн. "
+"Внимание уделяется самому необычному оружию, Поркупайн"
 
 # data/resource/tut_intr/00005-5BAS_NAV.txt:1
 msgid ""
@@ -4530,7 +4493,7 @@ msgid ""
 msgstr ""
 "В этих учебных уроках для семи королей мы рассмотрим все основные аспекты "
 "игры. Чтобы перейти к следующей или предыдущей странице урока, вы можете "
-"щёлкнуть на кнопки со стрелками на экране или нажать клавиши «<» и «>» на "
+"щёлкнуть на кнопки со стрелками на экране или нажать клавиши < и > на "
 "клавиатуре. Каждый урок начнётся с игры, работающей со скоростью 3. "
 "Нажимайте более высокие цифры на клавиатуре, чтобы ускорить движение, или "
 "нажмите более низкие цифры, чтобы замедлить работу. Нажатие 0 "
@@ -5437,9 +5400,9 @@ msgid ""
 "cause their loyalty to decrease, so taxing too much can be a dangerous "
 "proposition. "
 msgstr ""
-"Это немедленно освободит 5 долларов США от каждого жителя деревни. Это также "
-"приведёт к снижению их лояльности, поэтому слишком много налогов может быть "
-"опасным предложением. "
+"Это немедленно освободит $5 от каждого жителя деревни. Это также приведёт к "
+"снижению их лояльности, поэтому слишком много налогов может быть опасным "
+"предложением. "
 
 # data/resource/tut_text/00008-2BAS_ECO.txt:119
 msgid ""
@@ -5912,7 +5875,7 @@ msgid ""
 ". . . or build your own Markets within Linking distance of their Villages. "
 "Then you can send Caravans to drop your goods off near a foreign Village. "
 msgstr ""
-"...или строить свои собственные рынки в пределах расстояния между их "
+". . . или строить свои собственные рынки в пределах расстояния между их "
 "деревнями. Затем вы можете отправить караванов, чтобы бросить товары рядом с "
 "чужой деревней. "
 
@@ -7202,7 +7165,7 @@ msgstr ""
 
 # data/resource/help.res:30
 msgid "Ranking Report"
-msgstr "Рейтинг"
+msgstr "Отчет о Рейтинг"
 
 # data/resource/help.res:31
 msgid ""
@@ -7229,7 +7192,6 @@ msgid "Date"
 msgstr "Дата"
 
 # data/resource/help.res:43
-#, fuzzy
 msgid "This shows the current Date. "
 msgstr "Показывает текущую дату. "
 
@@ -7242,7 +7204,6 @@ msgid "Terrain Map"
 msgstr "Карта местности"
 
 # data/resource/help.res:51
-#, fuzzy
 msgid ""
 "This map shows the world's natural features and the location of villages and "
 "units. "
@@ -7271,7 +7232,6 @@ msgid "This map mode shows the location of villages and units. "
 msgstr "Показывает местоположение деревень и других объектов. "
 
 # data/resource/help.res:63
-#, fuzzy
 msgid ""
 "This takes you to a menu where you can select a bribe to offer to the "
 "selected person. "
@@ -7283,7 +7243,6 @@ msgid "Build"
 msgstr "Строить"
 
 # data/resource/help.res:67
-#, fuzzy
 msgid ""
 "This enables you to choose a structure to build. If you do not have enough "
 "money to build a structure, this tile will be disabled. "
@@ -7292,7 +7251,6 @@ msgstr ""
 "счету не достаточно золота, данная функция будет недоступна. "
 
 # data/resource/help.res:71
-#, fuzzy
 msgid "This cancels your present action. "
 msgstr "Позволяет отменить предыдущее действие. "
 
@@ -7301,7 +7259,6 @@ msgid "Capture"
 msgstr "Захватить"
 
 # data/resource/help.res:75
-#, fuzzy
 msgid "This captures the selected structure for your kingdom. "
 msgstr ""
 "Позволяет захватить выбранное строение и сделать своей собственностью. "
@@ -7311,7 +7268,6 @@ msgid "Change Production"
 msgstr "Сменить профиль производства"
 
 # data/resource/help.res:79
-#, fuzzy
 msgid ""
 "This toggles production in this factory between iron, copper, and clay "
 "products. "
@@ -7324,7 +7280,6 @@ msgid "Collect Tax"
 msgstr "Собрать налоги"
 
 # data/resource/help.res:83
-#, fuzzy
 msgid ""
 "This collects tax from the selected village. If you right-click on this, you "
 "will be able to tax your villagers automatically. "
@@ -7356,7 +7311,6 @@ msgid "Demote Unit"
 msgstr "Понизить в должности"
 
 # data/resource/help.res:98
-#, fuzzy
 msgid "This demotes the selected General to a common soldier. "
 msgstr "Позволяет понизить Генерала до рядового солдата. "
 
@@ -7368,7 +7322,6 @@ msgid "Grant"
 msgstr "Пожертвовать"
 
 # data/resource/help.res:102
-#, fuzzy
 msgid ""
 "This grants money to the selected village. If you right-click on this, you "
 "will be able to grant money automatically. "
@@ -7377,7 +7330,6 @@ msgstr ""
 "включает функцию автоматического пожертвования. "
 
 # data/resource/help.res:106
-#, fuzzy
 msgid ""
 "This grants money to the selected village to lower the villagers' loyalty or "
 "resistance. "
@@ -7390,7 +7342,6 @@ msgid "Hire Caravan"
 msgstr "Нанять караван"
 
 # data/resource/help.res:110
-#, fuzzy
 msgid ""
 "This hires a caravan from this market so that you can conduct trade. It is "
 "disabled if you have too few villagers to support any more caravans. 10 "
@@ -7413,7 +7364,6 @@ msgid "Invoke Greater Being"
 msgstr "Призвать Всевышнего"
 
 # data/resource/help.res:118
-#, fuzzy
 msgid ""
 "This invokes a Greater Being who will then appear over your Seat of Power. "
 "This tile is disabled until you have enough praying points to make "
@@ -7451,7 +7401,6 @@ msgid "Mobilize Workers"
 msgstr "Мобилизовать рабочих"
 
 # data/resource/help.res:130
-#, fuzzy
 msgid "This causes all workers to exit the building immediately. "
 msgstr "Принуждает всех рабочих немедленно покинуть здание "
 
@@ -7460,7 +7409,6 @@ msgid "Mobilize Spy"
 msgstr "Мобилизовать шпиона"
 
 # data/resource/help.res:134
-#, fuzzy
 msgid "This sends the selected spy out of the place where he has infiltrated. "
 msgstr "Заставляет выбранного шпиона покинуть место, в которое он проник. "
 
@@ -7469,7 +7417,6 @@ msgid "Disembark from Ship"
 msgstr "Разгрузить корабль"
 
 # data/resource/help.res:138
-#, fuzzy
 msgid ""
 "The disembarks all of the units from this ship. This tile is disabled if "
 "your ship is not close enough to the shore. "
@@ -7482,7 +7429,6 @@ msgid "Sortie"
 msgstr "Покинуть место"
 
 # data/resource/help.res:142
-#, fuzzy
 msgid "This sorties the troop from this fort. "
 msgstr "Принуждает войска покинуть границы форта. "
 
@@ -7491,7 +7437,6 @@ msgid "Withdraw"
 msgstr "Отозвать"
 
 # data/resource/help.res:146
-#, fuzzy
 msgid "This immediately withdraws your troop to its home fort. "
 msgstr "Принуждает войска вернуть в свой форт. "
 
@@ -7500,7 +7445,6 @@ msgid "Previous Menu"
 msgstr "Предыдущее меню"
 
 # data/resource/help.res:150
-#, fuzzy
 msgid "This returns you to the previous menu. "
 msgstr "Откроет предыдущее меню. "
 
@@ -7509,7 +7453,6 @@ msgid "Promote"
 msgstr "Повысить"
 
 # data/resource/help.res:154
-#, fuzzy
 msgid "This promotes the selected common soldier to a General. "
 msgstr "Позволяет повысить рядового солдата до генерала. "
 
@@ -7518,7 +7461,6 @@ msgid "Recruit"
 msgstr "Нанять новобранца"
 
 # data/resource/help.res:158
-#, fuzzy
 msgid ""
 "This recruits a peasant from the selected village. For each click, one "
 "peasant exits. This tile is disabled if there are no more peasants in the "
@@ -7533,7 +7475,6 @@ msgid "Conduct Research"
 msgstr "Начать исследование"
 
 # data/resource/help.res:162
-#, fuzzy
 msgid ""
 "This orders the start of a research project. This is disabled if all "
 "possible research has been completed. "
@@ -7551,7 +7492,6 @@ msgid "Honors"
 msgstr "Оказать честь"
 
 # data/resource/help.res:166
-#, fuzzy
 msgid ""
 "This awards an honor to the selected person. For each honor, the person's "
 "loyalty increases by 10 points. This is disabled for the King. "
@@ -7561,7 +7501,6 @@ msgstr ""
 "короля. "
 
 # data/resource/help.res:170
-#, fuzzy
 msgid ""
 "This awards an honor to the selected General or soldier in this fort. For "
 "each honor, the unit's loyalty increases by 10 points. This is disabled for "
@@ -7572,7 +7511,6 @@ msgstr ""
 "10 очков. Данная функция не доступна для короля. "
 
 # data/resource/help.res:174
-#, fuzzy
 msgid ""
 "This awards an honor to the selected General or prayer in this Seat of "
 "Power. For each honor, the unit's loyalty increases by 10 points. This is "
@@ -7653,7 +7591,6 @@ msgid "Notification currently disabled. Click to enable."
 msgstr "Уведомление отключено. Нажмите, чтобы включить."
 
 # data/resource/help.res:202
-#, fuzzy
 msgid ""
 "When this is disabled, it keeps your spy's change of color a secret. You "
 "retain the ability to control your spy's movement. "
@@ -7666,7 +7603,6 @@ msgid "Notification currently enabled. Click to disable."
 msgstr "Уведомление в настоящее время включено. Нажмите, чтобы отключить."
 
 # data/resource/help.res:206
-#, fuzzy
 msgid ""
 "When this is enabled, it announces your spy's change of color to the kingdom "
 "that he is joining. You lose your ability to control your spy's movement. "
@@ -7680,7 +7616,6 @@ msgid "Succeed to the Crown"
 msgstr "Наследовать престол"
 
 # data/resource/help.res:210
-#, fuzzy
 msgid "This elevates the selected person to the Crown. "
 msgstr "Это поднимет выбранного человека до престола. "
 
@@ -7689,13 +7624,12 @@ msgid "Train"
 msgstr "Тренировка"
 
 # data/resource/help.res:214
-#, fuzzy
 msgid ""
 "This trains a villager in a selected skill.  This tile is disabled if there "
 "are no more peasants in the village or if you do not have a General in a "
 "fort linked to the village. "
 msgstr ""
-"Это будет обучать сельского жителя в выбранном навыке. Эта плитка будет "
+"Это буд обучатет сельского жителя в выбранном навыке. Эта плитка будет "
 "отключена, если в деревне больше нет крестьянина, или если у вас нет "
 "генерала в крепости, связанной с деревней. "
 
@@ -7704,7 +7638,6 @@ msgid "View Secrets"
 msgstr "Показать секреты"
 
 # data/resource/help.res:218
-#, fuzzy
 msgid ""
 "This takes you to a menu where you can select the type of this kingdom's "
 "secrets to view. The secrets that you can view depends on the skill level of "
@@ -7719,7 +7652,6 @@ msgid "Drop spy identity"
 msgstr "Падение шпионской внешности"
 
 # data/resource/help.res:222
-#, fuzzy
 msgid "This causes the spy to give up his spying identity. "
 msgstr "Это заставит шпиона отказаться от своей шпионской внешности. "
 
@@ -7728,7 +7660,6 @@ msgid "Automatic"
 msgstr "Автоматический"
 
 # data/resource/help.res:226
-#, fuzzy
 msgid ""
 "With this set, your caravans and ships will automatically pick up the "
 "surplus goods from this market or harbor. "
@@ -7741,7 +7672,6 @@ msgid "Nothing"
 msgstr "Ничего"
 
 # data/resource/help.res:230
-#, fuzzy
 msgid ""
 "With this set, your caravans and ships will not pick up anything from this "
 "market or harbor. "
@@ -7754,7 +7684,6 @@ msgid "Disband a unit"
 msgstr "Расформировать юнит"
 
 # data/resource/help.res:234
-#, fuzzy
 msgid ""
 "This disbands the selected unit. If the selected unit is a foreign spy, this "
 "executes him. "
@@ -7779,7 +7708,6 @@ msgid "View a caravan's trade stop"
 msgstr "Посмотреть торговую остановку каравана"
 
 # data/resource/help.res:242
-#, fuzzy
 msgid "This centers your screen over this caravan stop. "
 msgstr "Это остановит ваш экран над этой остановкой каравана. "
 
@@ -7788,7 +7716,6 @@ msgid "Delete a caravan's trade stop"
 msgstr "Удалить торговую остановку каравана"
 
 # data/resource/help.res:246
-#, fuzzy
 msgid "Clicking here deletes this caravan trade stop. "
 msgstr "Щелчок здесь удалит эту остановку каравана. "
 
@@ -7809,7 +7736,6 @@ msgid "View a ship's trade stop"
 msgstr "Посмотреть торговую остановку коробля"
 
 # data/resource/help.res:254
-#, fuzzy
 msgid "This centers your screen over this ship's trading stop. "
 msgstr "Это центрирует ваш экран над торговой остановкой этого корабля. "
 
@@ -7818,7 +7744,6 @@ msgid "Delete a ship's trade stop"
 msgstr "Отменить торговую остановку коробля"
 
 # data/resource/help.res:258
-#, fuzzy
 msgid "Clicking here deletes this ship's trade stop. "
 msgstr "Щелчок здесь удалит торговую остановку этого корабля. "
 
@@ -7827,7 +7752,6 @@ msgid "Demolish a structure"
 msgstr "Снести сооружение"
 
 # data/resource/help.res:262
-#, fuzzy
 msgid "Clicking here demolishs this structure. "
 msgstr "Щелчок здесь разрушит это сооружение. "
 
@@ -7836,7 +7760,6 @@ msgid "Sell a structure"
 msgstr "Продать сооружение"
 
 # data/resource/help.res:266
-#, fuzzy
 msgid "Clicking here sells this structure. "
 msgstr "Щелкнув здесь вы продадите это сооружение. "
 
@@ -7988,7 +7911,6 @@ msgid "Cancel building this structure."
 msgstr "Отмените строительство этой структуры."
 
 # data/resource/help.res:334
-#, fuzzy
 msgid "Clicking here cancels the building of this structure. "
 msgstr "Щелчок здесь отменяет здание этой структуры. "
 
@@ -8070,10 +7992,9 @@ msgstr ""
 
 # data/resource/help.res:369
 msgid "Passive Mode Enabled. Click for Aggressive Mode"
-msgstr "Пассивный режим включен. Нажмите для агрессивного режима"
+msgstr "Пассивный режим включен. Нажмите для Агрессия"
 
 # data/resource/help.res:370
-#, fuzzy
 msgid ""
 "When toggled to this mode, your units will not fight unless attacked. If "
 "ordered to change location, they will not stop to fight off an attack. "
@@ -8084,10 +8005,9 @@ msgstr ""
 
 # data/resource/help.res:373
 msgid "Aggressive Mode Enabled. Click for Passive Mode"
-msgstr "Агрессивный режим включен. Нажмите для пассивного режима"
+msgstr "Агрессивный режим включен. Нажмите для Пассивность"
 
 # data/resource/help.res:374
-#, fuzzy
 msgid ""
 "When toggled to this mode, your units will automatically attack an enemy in "
 "their area, but they will not follow it out of the area. If ordered to "
@@ -8128,7 +8048,6 @@ msgid "Change Loyalty"
 msgstr "Изменение лояльности"
 
 # data/resource/help.res:386
-#, fuzzy
 msgid ""
 "When you Click on this tile, your cursor will change into a large white "
 "circle. Place this circle over your target and Click again. Repeat until the "
@@ -8143,7 +8062,6 @@ msgid "Increase power of Maya Soldiers"
 msgstr "Увеличивает силу солдат Майя"
 
 # data/resource/help.res:390
-#, fuzzy
 msgid ""
 "When you Click on this tile, your cursor will change into a large white "
 "circle. Place this circle over your soldiers and Click again. Repeat until "
@@ -8158,7 +8076,6 @@ msgid "Summon Rain"
 msgstr "Призыв дождя"
 
 # data/resource/help.res:394
-#, fuzzy
 msgid ""
 "When you Click on this tile, it will cause the rains to come to the whole "
 "world. Repeat until Thor's power has been depleted. "
@@ -8171,7 +8088,6 @@ msgid "Summon Tornadoes"
 msgstr "Призыв торнадо"
 
 # data/resource/help.res:398
-#, fuzzy
 msgid ""
 "When you Click on this, tile your cursor will change into a small square. "
 "Place this square over your target and Click again. Repeat until Thor's "


### PR DESCRIPTION
"Can’t automatically merge." I suspect this isn't an issue.

Russian Translation Update

fixed a number of things such as over flowing text via abbreviation and paraphrasing or eliminating text that was not needed for understanding. note some text still overflows. removed fuzzy flags. all fuzzy flags have been removed, but that doesnt mean the translation is perfect. fixed some things like %s and exclamation marks.

Authors:
Natalie Feotistova <feonapost@gmail.com>
Timothy Rink <timothyrink28@gmail.com>

Clean up of the Manual and Minor Changes

Minor clean up of the text such as fixing text not displaying properly due to incorrect tex usage.
Eliminated most Wiki text except for section discribing ports.
Credited microvirus (richard Dijk) for the information I used from his hotkey documentation.
Added more hotkey documentation.
Edited installation instructions