### PR TITLE
Fix various VS compiler warnings

### DIFF
--- a/include/OSTR.h
+++ b/include/OSTR.h
@@ -50,7 +50,7 @@ public:
    char*  lower();
    int    len()         { return strlen(str_buf); }
    int    at(char*);
-   void   catf(char *format, ...);
+   void   catf(const char *format, ...);
 
    char*  right(int needLen)           { return substr( len()-needLen ); }
    char*  left(int needLen)             { return substr( 0, needLen ); }

--- a/src/OSTR.cpp
+++ b/src/OSTR.cpp
@@ -152,7 +152,7 @@ int String::at(char* searchStr)
 //
 // A formatted string concatenation
 //
-void String::catf(char *format, ...)
+void String::catf(const char *format, ...)
 {
    va_list valist;
    va_start(valist, format);

--- a/src/OU_MONS.cpp
+++ b/src/OU_MONS.cpp
@@ -55,7 +55,7 @@ char* UnitMonster::unit_name(int withTitle)
 {
 	static String str;
 
-	char* monsterName = _(monster_res[get_monster_id()]->name);
+	char const * monsterName = _(monster_res[get_monster_id()]->name);
 
 	str = "";
 

--- a/src/OVGA.cpp
+++ b/src/OVGA.cpp
@@ -913,8 +913,8 @@ typedef enum PROCESS_DPI_AWARENESS {
    PROCESS_PER_MONITOR_DPI_AWARE = 2
 } PROCESS_DPI_AWARENESS;
 
-BOOL(WINAPI *SetProcessDPIAware)(void); // Vista and later
-HRESULT(WINAPI *SetProcessDpiAwareness)(PROCESS_DPI_AWARENESS dpiAwareness); // Windows 8.1 and later
+BOOL(WINAPI *pSetProcessDPIAware)(void); // Vista and later
+HRESULT(WINAPI *pSetProcessDPIAwareness)(PROCESS_DPI_AWARENESS dpiAwareness); // Windows 8.1 and later
 
 // Based on the example provided by Eric Wasylishen
 // https://discourse.libsdl.org/t/sdl-getdesktopdisplaymode-resolution-reported-in-windows-10-when-using-app-scaling/22389
@@ -926,28 +926,28 @@ static void init_dpi()
    shcoreDLL = SDL_LoadObject("SHCORE.DLL");
    if (shcoreDLL)
    {
-      SetProcessDpiAwareness = (HRESULT(WINAPI *)(PROCESS_DPI_AWARENESS)) SDL_LoadFunction(shcoreDLL, "SetProcessDpiAwareness");
+      pSetProcessDPIAwareness = (HRESULT(WINAPI *)(PROCESS_DPI_AWARENESS)) SDL_LoadFunction(shcoreDLL, "pSetProcessDPIAwareness");
    }
 
-   if (SetProcessDpiAwareness)
+   if (pSetProcessDPIAwareness)
    {
       /* Try Windows 8.1+ version */
-      HRESULT result = SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
+      HRESULT result = pSetProcessDPIAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
       return;
    }
 
    userDLL = SDL_LoadObject("USER32.DLL");
    if (userDLL)
    {
-      SetProcessDPIAware = (BOOL(WINAPI *)(void)) SDL_LoadFunction(userDLL, "SetProcessDPIAware");
+      pSetProcessDPIAware = (BOOL(WINAPI *)(void)) SDL_LoadFunction(userDLL, "pSetProcessDPIAware");
    }
 
-   if (SetProcessDPIAware)
+   if (pSetProcessDPIAware)
    {
       /* Try Vista - Windows 8 version.
       This has a constant scale factor for all monitors.
       */
-      BOOL success = SetProcessDPIAware();
+      BOOL success = pSetProcessDPIAware();
    }
 }
 


### PR DESCRIPTION
This fixes a few const/non-const conversions that throw errors on the latest VS2015. Also, the `SetProcessDPIAware` and `SetProcessDPIAwareness` function pointer names were prefixed with a `p` due to name collisions if the currently-targeted Windows SDK already includes those functions, like they do on mine.