### PR TITLE
Fixed issue with only a white screen appearing in a debug session

### DIFF
--- a/src/OSYS.cpp
+++ b/src/OSYS.cpp
@@ -274,6 +274,7 @@ int Sys::init_directx()
       DEBUG_LOG("Attempt vga_true_front.init_front()");
       vga_true_front.init(1);
       DEBUG_LOG("Attempt vga.activate_pal()");
+      vga.activate_pal (&vga_front);
       vga.activate_pal(&vga_true_front);
       DEBUG_LOG("vga.activate_pal() finish");
    }


### PR DESCRIPTION
In a debug session vga_true_front should be the front buffer, but it seems currently that vga_front is.
This may be a further 'bug', but for now a quick fix to at least not be bothered by it is to initialise the palette on both buffers.