### PR TITLE
Player Stats & Scenario Completion Tracking

### DIFF
--- a/include/OGAME.h
+++ b/include/OGAME.h
@@ -73,9 +73,10 @@ struct ScenInfo
 
 	char* 	file_name;
 	char  	scen_name[SCEN_NAME_LEN+1];
-	char		dir_id;			// real path look from DIR_SCENARIO_PATH(dir_id)
-	short		goal_difficulty;
+	char	dir_id;			// real path look from DIR_SCENARIO_PATH(dir_id)
+	short	goal_difficulty;
 	short 	goal_score_bonus;
+	int		play_status;
 };
 
 //-------- Define class Game -----------//

--- a/include/OGFILE.h
+++ b/include/OGFILE.h
@@ -41,7 +41,8 @@ public:
 
    // Reads the given file and fills the save game info from the header. Returns true if successful.
    static bool read_header(const char* filePath, SaveGameInfo* /*out*/ saveGameInfo);
-
+   // Reads the internal file name stored in the header. Returns null on failure.
+   static char * read_internal_file_name(const char* filePath);
    static const char *status_str();
 
 public:

--- a/include/OSaveGameInfo.h
+++ b/include/OSaveGameInfo.h
@@ -39,7 +39,10 @@ struct SaveGameTime
 struct SaveGameInfo
 {
 	enum { MAX_FILE_PATH = 260 };
-	char     file_name[MAX_FILE_PATH+1]; // unused
+	union {
+		char     file_name[MAX_FILE_PATH + 1]; // unused
+		char     game_name[MAX_FILE_PATH + 1]; // used to track a scenario's original name so we know if a saved game is from a scenario
+	};
 	char     player_name[HUMAN_NAME_LEN+1];
 
 	char     race_id;
@@ -51,6 +54,9 @@ struct SaveGameInfo
 };
 #pragma pack()
 
+//
+// Sets various SaveGameInfo vars from the current game.
+//
 SaveGameInfo SaveGameInfoFromCurrentGame(const char* newFileName);
 
 #endif // ! __OSAVEGAMEINFO_H

--- a/include/PlayerStats.h
+++ b/include/PlayerStats.h
@@ -29,9 +29,11 @@
 #include <ODYNARR.h>
 #endif
 
-enum PlayStatus : int { UNPLAYED = 0, PLAYED = 1, COMPLETED = 2 };
 
 namespace nsPlayerStats {
+
+enum PlayStatus : int { UNPLAYED = 0, PLAYED = 1, COMPLETED = 2 };
+
 namespace detail {
 
 char const * const scn_dat_file = "PLAYSTAT.DAT";

--- a/include/PlayerStats.h
+++ b/include/PlayerStats.h
@@ -49,15 +49,10 @@ typedef struct {
 	//
 	char internal_name[MAX_FILE_PATH + 1];
 	PlayStatus status;
-	//
-	// Room for expansion later. Just subtract
-	// the size of your new value from this
-	//
-	char reserved_for_later[120];
 } ScenStat;
 
 static_assert(sizeof(ScenStat::internal_name) == MAX_FILE_PATH + 1, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");
-static_assert(sizeof(ScenStat) == 385, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");
+static_assert(sizeof(ScenStat) == 265, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");
 
 }
 

--- a/include/PlayerStats.h
+++ b/include/PlayerStats.h
@@ -53,8 +53,7 @@ typedef struct {
 	// Room for expansion later. Just subtract
 	// the size of your new value from this
 	//
-	char reserved_for_later[119];
-	char newl = '\n';
+	char reserved_for_later[120];
 } ScenStat;
 
 static_assert(sizeof(ScenStat::internal_name) == MAX_FILE_PATH + 1, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");

--- a/include/PlayerStats.h
+++ b/include/PlayerStats.h
@@ -1,0 +1,59 @@
+/*
+* Seven Kingdoms: Ancient Adversaries
+*
+* Copyright 2019 Steven Lavoie
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+//Filename    : PlayerStats.h
+//Description : Handles file IO for player statistics information
+
+#ifndef __PLAYERSTATS_H
+#define __PLAYERSTATS_H
+
+#include <OGAME.h>
+#ifndef __ODYNARR_H
+#include <ODYNARR.h>
+#endif
+
+enum PlayStatus : int { UNPLAYED = 0, PLAYED = 1, COMPLETED = 2 };
+
+namespace player_stat_detail {
+enum { MAX_FILE_PATH = 260 };
+typedef struct {
+	char internal_name[MAX_FILE_PATH + 1]; //HACK: Use global max file name
+	PlayStatus status;
+} ScenarioStats;
+}
+
+
+class PlayerStats
+{
+private:
+	player_stat_detail::ScenarioStats * scene_stats = nullptr;
+	size_t scene_stats_len = 0;
+
+	FILE * open_scenario_file(bool read);
+	bool load_scenario_file();
+
+public:
+	PlayStatus get_scenario_play_status(char const * name);
+	bool save_scenario_stat(char const * name, PlayStatus status);
+	PlayerStats();
+	~PlayerStats();
+};
+
+#endif

--- a/include/PlayerStats.h
+++ b/include/PlayerStats.h
@@ -53,7 +53,8 @@ typedef struct {
 	// Room for expansion later. Just subtract
 	// the size of your new value from this
 	//
-	char reserved_for_later[120];
+	char reserved_for_later[119];
+	char newl = '\n';
 } ScenStat;
 
 static_assert(sizeof(ScenStat::internal_name) == MAX_FILE_PATH + 1, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");
@@ -68,13 +69,18 @@ private:
 	size_t scn_stat_arr_len;
 
 	bool write_scenario_file();
-	bool load_scenario_file();
 
 public:
 	PlayStatus get_scenario_play_status(char const * name);
 	bool set_scenario_play_status(char const * name, PlayStatus status);
+	// If force_reload==true, the stats will be reloaded from the file or,
+	// if the file is deleted, the UI will be updated to reflect that
+	bool load_scenario_file(bool force_reload = false);
+
 	PlayerStats();
 	~PlayerStats();
 };
 } // nsPlayerStats
+
+extern nsPlayerStats::PlayerStats playerStats; // in AM.cpp
 #endif

--- a/include/PlayerStats.h
+++ b/include/PlayerStats.h
@@ -32,8 +32,8 @@
 
 namespace nsPlayerStats {
 
-enum PlayStatus : int { UNPLAYED = 0, PLAYED = 1, COMPLETED = 2 };
-enum RecordType : int { ScenarioPlayStatus = 0 };
+enum PlayStatus : uint32_t { UNPLAYED = 0, PLAYED = 1, COMPLETED = 2 };
+enum RecordType : uint32_t { ScenarioPlayStatus = 0 };
 
 namespace detail {
 

--- a/include/PlayerStats.h
+++ b/include/PlayerStats.h
@@ -48,9 +48,9 @@ enum { MAX_FILE_PATH = 260 }; //HACK: This is repeated all over. Should be globa
 
 //
 // Dictates the reading/writing of the file. Every type of statistic
-// must be preceded by a RecordHeader.
+// must be preceded by a RecordHeader. This struct is written as-is
+// to/from an array and file so ensure any changes are 4-byte aligned.
 //
-#pragma pack(1)
 struct RecordHeader {
 	RecordType rec_type;
 	uint32_t rec_count;
@@ -59,19 +59,23 @@ struct RecordHeader {
 static_assert(sizeof(RecordHeader) == 12, "Changing RecordHeader is a breaking change for PLAYSTAT.DAT");
 
 //
-// Tracks whether a scenario has been played/completed
+// Tracks whether a scenario has been played/completed. This
+// struct is written as-is to/from an array and file so ensure
+// any changes are 4-byte aligned.
 //
-#pragma pack(1)
 struct ScenStat {
 	//
-	// This size is dictated by SAV format and is a legacy requirement
+	// The SAV format actually has MAX_FILE_PATH + 1, which was stupid. Since
+	// this field is not actively used and even legacy scenario files only contain
+	// an 8.3 filename, we'll dispense with the extra byte. Windows includes /0 in
+	// its MAX_PATH's 260 bytes anyway.
 	//
-	char internal_name[MAX_FILE_PATH + 1];
+	char internal_name[MAX_FILE_PATH];
 	PlayStatus status;
 };
 
-static_assert(sizeof(ScenStat::internal_name) == MAX_FILE_PATH + 1, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");
-static_assert(sizeof(ScenStat) == 265, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");
+static_assert(sizeof(ScenStat::internal_name) == MAX_FILE_PATH, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");
+static_assert(sizeof(ScenStat) == 264, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");
 
 }
 

--- a/include/PlayerStats.h
+++ b/include/PlayerStats.h
@@ -31,22 +31,41 @@
 
 enum PlayStatus : int { UNPLAYED = 0, PLAYED = 1, COMPLETED = 2 };
 
-namespace player_stat_detail {
-enum { MAX_FILE_PATH = 260 };
-typedef struct {
-	char internal_name[MAX_FILE_PATH + 1]; //HACK: Use global max file name
-	PlayStatus status;
-} ScenarioStats;
-}
+namespace nsPlayerStats {
+namespace detail {
 
+char const * const scn_dat_file = "PLAYSTAT.DAT";
+enum { MAX_FILE_PATH = 260 }; //HACK: This is repeated all over. Should be global constant.
+
+//
+// This structure is written as-is to PLAYSTAT.DAT
+//
+#pragma pack(1)
+typedef struct {
+	//
+	// This size is dictated by SAV format and is a legacy requirement
+	//
+	char internal_name[MAX_FILE_PATH + 1];
+	PlayStatus status;
+	//
+	// Room for expansion later. Just subtract
+	// the size of your new value from this
+	//
+	char reserved_for_later[120];
+} ScenStat;
+
+static_assert(sizeof(ScenStat::internal_name) == MAX_FILE_PATH + 1, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");
+static_assert(sizeof(ScenStat) == 385, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");
+
+}
 
 class PlayerStats
 {
 private:
-	player_stat_detail::ScenarioStats * scene_stats = nullptr;
-	size_t scene_stats_len = 0;
+	detail::ScenStat * scn_stat_arr;
+	size_t scn_stat_arr_len;
 
-	FILE * open_scenario_file(bool read);
+	bool write_scenario_file();
 	bool load_scenario_file();
 
 public:
@@ -55,5 +74,5 @@ public:
 	PlayerStats();
 	~PlayerStats();
 };
-
+} // nsPlayerStats
 #endif

--- a/include/PlayerStats.h
+++ b/include/PlayerStats.h
@@ -33,6 +33,7 @@
 namespace nsPlayerStats {
 
 enum PlayStatus : int { UNPLAYED = 0, PLAYED = 1, COMPLETED = 2 };
+enum RecordType : int { ScenarioPlayStatus = 0 };
 
 namespace detail {
 
@@ -40,7 +41,25 @@ char const * const scn_dat_file = "PLAYSTAT.DAT";
 enum { MAX_FILE_PATH = 260 }; //HACK: This is repeated all over. Should be global constant.
 
 //
-// This structure is written as-is to PLAYSTAT.DAT
+// These structures are written as-is to PLAYSTAT.DAT and cannot be changed
+// without breaking the format. To prevent breaking changes, just add a new
+// record type that includes whatever additional data.
+//
+
+//
+// Dictates the reading/writing of the file. Every type of statistic
+// must be preceded by a RecordHeader.
+//
+#pragma pack(1)
+struct RecordHeader {
+	RecordType rec_type;
+	uint32_t rec_count;
+	uint32_t rec_size;
+};
+static_assert(sizeof(RecordHeader) == 12, "Changing RecordHeader is a breaking change for PLAYSTAT.DAT");
+
+//
+// Tracks whether a scenario has been played/completed
 //
 #pragma pack(1)
 struct ScenStat {
@@ -62,14 +81,14 @@ private:
 	detail::ScenStat * scn_stat_arr;
 	size_t scn_stat_arr_len;
 
-	bool write_scenario_file();
+	bool write_player_stats();
 
 public:
 	PlayStatus get_scenario_play_status(char const * name);
 	bool set_scenario_play_status(char const * name, PlayStatus status);
 	// If force_reload==true, the stats will be reloaded from the file or,
 	// if the file is deleted, the UI will be updated to reflect that
-	bool load_scenario_file(bool force_reload = false);
+	bool load_player_stats(bool force_reload = false);
 
 	PlayerStats();
 	~PlayerStats();

--- a/include/PlayerStats.h
+++ b/include/PlayerStats.h
@@ -72,7 +72,7 @@ private:
 
 public:
 	PlayStatus get_scenario_play_status(char const * name);
-	bool save_scenario_stat(char const * name, PlayStatus status);
+	bool set_scenario_play_status(char const * name, PlayStatus status);
 	PlayerStats();
 	~PlayerStats();
 };

--- a/include/PlayerStats.h
+++ b/include/PlayerStats.h
@@ -43,13 +43,13 @@ enum { MAX_FILE_PATH = 260 }; //HACK: This is repeated all over. Should be globa
 // This structure is written as-is to PLAYSTAT.DAT
 //
 #pragma pack(1)
-typedef struct {
+struct ScenStat {
 	//
 	// This size is dictated by SAV format and is a legacy requirement
 	//
 	char internal_name[MAX_FILE_PATH + 1];
 	PlayStatus status;
-} ScenStat;
+};
 
 static_assert(sizeof(ScenStat::internal_name) == MAX_FILE_PATH + 1, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");
 static_assert(sizeof(ScenStat) == 265, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");

--- a/src/AM.cpp
+++ b/src/AM.cpp
@@ -109,6 +109,7 @@
 #include <dbglog.h>
 #include <CmdLine.h>
 #include <LocaleRes.h>
+#include <PlayerStats.h>
 #include "gettext.h"
 
 //------- define game version constant --------//
@@ -236,6 +237,7 @@ SaveGameArray     save_game_array;
 // tutor files, just pass this in to load_scenario().
 //
 SaveGameInfo	  current_game_info;
+nsPlayerStats::PlayerStats playerStats;
 HallOfFame        hall_of_fame;
 // ###### begin Gilbert 23/10 #######//
 OptionMenu			option_menu;

--- a/src/AM.cpp
+++ b/src/AM.cpp
@@ -230,6 +230,12 @@ Battle            battle;
 Power             power;
 World             world;
 SaveGameArray     save_game_array;
+//
+// For regular game files, copy the SaveGameInfo over after calling
+// load_game (see SaveGameArray::process_action). For scenarios or
+// tutor files, just pass this in to load_scenario().
+//
+SaveGameInfo	  current_game_info;
 HallOfFame        hall_of_fame;
 // ###### begin Gilbert 23/10 #######//
 OptionMenu			option_menu;

--- a/src/OGAMEND.cpp
+++ b/src/OGAMEND.cpp
@@ -62,7 +62,6 @@ static void put_stat(int y, const char* desStr, const char* dispStr);
 static void put_stat(int y, const char* desStr, int dispValue);
 static void put_ranking(int y, int nationRecno);
 
-static nsPlayerStats::PlayerStats ps;
 extern SaveGameInfo current_game_info;
 
 //---------- Begin of function Game::game_end --------//
@@ -80,7 +79,7 @@ void Game::game_end(int winNationRecno, int playerDestroyed, int surrenderToNati
 {
 	//--- set scenario as complete if they didn't retire ---//
 	if(!retireFlag)
-		ps.set_scenario_play_status(current_game_info.game_name, nsPlayerStats::PlayStatus::COMPLETED);
+		playerStats.set_scenario_play_status(current_game_info.game_name, nsPlayerStats::PlayStatus::COMPLETED);
 
 	//--- skip all game ending screens if in demo mode ---//
 

--- a/src/OGAMEND.cpp
+++ b/src/OGAMEND.cpp
@@ -41,6 +41,7 @@
 #include <OMUSIC.h>
 #include <OOPTMENU.h>
 #include <OINGMENU.h>
+#include <PlayerStats.h>
 // ####### begin Gilbert 29/10 ########//
 #include <OPOWER.h>
 // ####### end Gilbert 29/10 ########//
@@ -61,6 +62,8 @@ static void put_stat(int y, const char* desStr, const char* dispStr);
 static void put_stat(int y, const char* desStr, int dispValue);
 static void put_ranking(int y, int nationRecno);
 
+static nsPlayerStats::PlayerStats ps;
+extern SaveGameInfo current_game_info;
 
 //---------- Begin of function Game::game_end --------//
 //
@@ -75,6 +78,10 @@ static void put_ranking(int y, int nationRecno);
 //
 void Game::game_end(int winNationRecno, int playerDestroyed, int surrenderToNationRecno, int retireFlag)
 {
+	//--- set scenario as complete if they didn't retire ---//
+	if(!retireFlag)
+		ps.set_scenario_play_status(current_game_info.game_name, nsPlayerStats::PlayStatus::COMPLETED);
+
 	//--- skip all game ending screens if in demo mode ---//
 
 	if( game_mode == GAME_DEMO )

--- a/src/OGAMSCE2.cpp
+++ b/src/OGAMSCE2.cpp
@@ -39,6 +39,7 @@
 #include <OFILETXT.h>
 #include <OVQUEUE.h>
 #include <OGETA.h>
+#include <PlayerStats.h>
 // ####### begin Gilbert 4/11 #######//
 #include <OMUSIC.h>
 // ####### end Gilbert 4/11 #######//
@@ -404,6 +405,46 @@ int Game::select_scenario(int scenCount, ScenInfo* scenInfoArray)
 
 							textX = font_bible.put(textX, browseSlotY1+TEXT_OFFSET_Y,
 								_(scenInfoArray[rec-1].scen_name), 0, browseSlotX2 );
+
+							//---- display the scenario's play status ----//
+
+							// UNPLAYED  = Empty checkbox
+							// PLAYED    = Line in checkbox
+							// COMPLETED = Checked
+
+							int x = browseSlotX1 + TEXT_OFFSET_X + 675;
+							int y = browseSlotY1 + TEXT_OFFSET_Y + 5;
+
+							if (scenInfoArray[rec - 1].play_status == nsPlayerStats::PlayStatus::COMPLETED) {
+								image_menu.put_front(x, y, "NMPG-RCH");             // Checked checkbox
+							}
+							else                                                    // Unchecked checkbox
+							{
+								//
+								// We need an empty checkbox to start. It stays that way for an
+								// UNPLAYED scenario. We'll draw a line inside for PLAYED.
+								//
+
+								//---- draw a pseudo-3D empty checkbox ----//
+								vga_front.rect(x, y, x + 14, y + 14, 10, V_WHITE); // white background
+								vga_front.line(x, y, x + 14, y, V_WHITE - 8);      // top
+								vga_front.line(x, y, x, y + 14, V_WHITE - 8);      // left
+								x += 1;
+								y += 1;
+								vga_front.line(x, y, x + 13, y, V_WHITE - 6);	   // inner shadow top
+								vga_front.line(x, y, x, y + 13, V_WHITE - 6);	   // inner shadow left
+								x += 1;
+								y += 1;
+								vga_front.rect(x, y, x + 12, y + 12, 1, V_WHITE - 1);  // another inner shadow
+
+								if (scenInfoArray[rec - 1].play_status == nsPlayerStats::PlayStatus::PLAYED)   // Line in the middle
+								{
+									vga_front.line(x + 1, y + 4, x + 11, y + 4, VGA_GRAY + 4);  // Dark gray line
+									vga_front.line(x + 1, y + 5, x + 11, y + 5, VGA_GRAY + 4);  // Dark gray line
+									vga_front.line(x + 1, y + 6, x + 11, y + 6, VGA_GRAY + 4);  // Dark gray line
+									vga_front.line(x + 2, y + 7, x + 12, y + 7, V_WHITE - 8);   // slight shadow bottom-right
+								}
+							}
 
 							//---- display the scenario difficulty and bonus points ----//
 

--- a/src/OGAMSCE2.cpp
+++ b/src/OGAMSCE2.cpp
@@ -40,6 +40,7 @@
 #include <OVQUEUE.h>
 #include <OGETA.h>
 #include <PlayerStats.h>
+#include <OGFILE.h>
 // ####### begin Gilbert 4/11 #######//
 #include <OMUSIC.h>
 // ####### end Gilbert 4/11 #######//
@@ -48,7 +49,8 @@
 // --------- declare static funtion --------//
 
 static void disp_scroll_bar_func(SlideVBar *scroll, int);
-
+enum CHECKBOX_STATE { UNCHECKED = 0, PART_CHECKED = 1, CHECKED = 2 };
+static void draw_checkbox(int x, int y, CHECKBOX_STATE checked);
 
 enum { TUTOR_MENU_X1 = 0,
 		 TUTOR_MENU_Y1 = 0,
@@ -109,6 +111,49 @@ enum {
 // ##### end Gilbert 1/11 ########//
 #define TUOPTION_ALL           0xffffffff
 
+//---------- Begin of function draw_checkbox ----------//
+//
+// Though we check for PlayStatus here, this is a very general
+// purpose function and can be used anywhere with ints instead.
+//
+void draw_checkbox(int x, int y, CHECKBOX_STATE checked)
+{
+	// UNPLAYED  = Empty checkbox
+	// PLAYED    = Line in checkbox
+	// COMPLETED = Checked
+
+	if (checked == CHECKBOX_STATE::CHECKED) {
+		image_menu.put_front(x, y, "NMPG-RCH");             // Checked checkbox
+	}
+	else                                                    // Unchecked checkbox
+	{
+		//
+		// We need an empty checkbox to start. It stays that way for an
+		// UNCHECKED box. We'll draw a line inside for PART_CHECKED.
+		//
+
+		//---- draw a pseudo-3D empty checkbox ----//
+		vga_front.rect(x, y, x + 14, y + 14, 10, V_WHITE); // white background
+		vga_front.line(x, y, x + 14, y, V_WHITE - 8);      // top
+		vga_front.line(x, y, x, y + 14, V_WHITE - 8);      // left
+		x += 1;
+		y += 1;
+		vga_front.line(x, y, x + 13, y, V_WHITE - 6);	   // inner shadow top
+		vga_front.line(x, y, x, y + 13, V_WHITE - 6);	   // inner shadow left
+		x += 1;
+		y += 1;
+		vga_front.rect(x, y, x + 12, y + 12, 1, V_WHITE - 1);  // another inner shadow
+
+		if (checked == CHECKBOX_STATE::PART_CHECKED)   // Line in the middle
+		{
+			vga_front.line(x + 1, y + 4, x + 11, y + 4, VGA_GRAY + 4);  // Dark gray line
+			vga_front.line(x + 1, y + 5, x + 11, y + 5, VGA_GRAY + 4);  // Dark gray line
+			vga_front.line(x + 1, y + 6, x + 11, y + 6, VGA_GRAY + 4);  // Dark gray line
+			vga_front.line(x + 2, y + 7, x + 12, y + 7, V_WHITE - 8);   // slight shadow bottom-right
+		}
+	}
+}
+//---------- End of function draw_checkbox ----------//
 
 //---------- Begin of function Game::select_scenario ----------//
 //
@@ -408,43 +453,9 @@ int Game::select_scenario(int scenCount, ScenInfo* scenInfoArray)
 
 							//---- display the scenario's play status ----//
 
-							// UNPLAYED  = Empty checkbox
-							// PLAYED    = Line in checkbox
-							// COMPLETED = Checked
-
-							int x = browseSlotX1 + TEXT_OFFSET_X + 675;
-							int y = browseSlotY1 + TEXT_OFFSET_Y + 5;
-
-							if (scenInfoArray[rec - 1].play_status == nsPlayerStats::PlayStatus::COMPLETED) {
-								image_menu.put_front(x, y, "NMPG-RCH");             // Checked checkbox
-							}
-							else                                                    // Unchecked checkbox
-							{
-								//
-								// We need an empty checkbox to start. It stays that way for an
-								// UNPLAYED scenario. We'll draw a line inside for PLAYED.
-								//
-
-								//---- draw a pseudo-3D empty checkbox ----//
-								vga_front.rect(x, y, x + 14, y + 14, 10, V_WHITE); // white background
-								vga_front.line(x, y, x + 14, y, V_WHITE - 8);      // top
-								vga_front.line(x, y, x, y + 14, V_WHITE - 8);      // left
-								x += 1;
-								y += 1;
-								vga_front.line(x, y, x + 13, y, V_WHITE - 6);	   // inner shadow top
-								vga_front.line(x, y, x, y + 13, V_WHITE - 6);	   // inner shadow left
-								x += 1;
-								y += 1;
-								vga_front.rect(x, y, x + 12, y + 12, 1, V_WHITE - 1);  // another inner shadow
-
-								if (scenInfoArray[rec - 1].play_status == nsPlayerStats::PlayStatus::PLAYED)   // Line in the middle
-								{
-									vga_front.line(x + 1, y + 4, x + 11, y + 4, VGA_GRAY + 4);  // Dark gray line
-									vga_front.line(x + 1, y + 5, x + 11, y + 5, VGA_GRAY + 4);  // Dark gray line
-									vga_front.line(x + 1, y + 6, x + 11, y + 6, VGA_GRAY + 4);  // Dark gray line
-									vga_front.line(x + 2, y + 7, x + 12, y + 7, V_WHITE - 8);   // slight shadow bottom-right
-								}
-							}
+							draw_checkbox(browseSlotX1 + TEXT_OFFSET_X + 675,
+										  browseSlotY1 + TEXT_OFFSET_Y + 5,
+										  static_cast<CHECKBOX_STATE>(scenInfoArray[rec - 1].play_status));
 
 							//---- display the scenario difficulty and bonus points ----//
 
@@ -536,11 +547,14 @@ int Game::select_scenario(int scenCount, ScenInfo* scenInfoArray)
 		}
 		else if( mouse.single_click( menuX1+BROWSE_X1, menuY1+BROWSE_Y1, 
 			menuX1+BROWSE_X1+BROWSE_REC_WIDTH-1, 
-			menuY1+BROWSE_Y1+ BROWSE_REC_HEIGHT*MAX_BROWSE_DISP_REC -1) )
+			menuY1+BROWSE_Y1+ BROWSE_REC_HEIGHT*MAX_BROWSE_DISP_REC -1, 2) )
 		{
+			int btn;
+			if (mouse.left_press) { btn = 0; }
+			else if (mouse.right_press) { btn = 1; }
 			// click on game slot
 			int oldValue = browseRecno;
-			int newValue = scrollBar.view_recno + (mouse.click_y(0) - BROWSE_Y1 - menuY1) / BROWSE_REC_HEIGHT;
+			int newValue = scrollBar.view_recno + (mouse.click_y(btn) - BROWSE_Y1 - menuY1) / BROWSE_REC_HEIGHT;
 			if( newValue <= scenCount )
 			{
 				if( oldValue != newValue )
@@ -551,6 +565,32 @@ int Game::select_scenario(int scenCount, ScenInfo* scenInfoArray)
 						| TUOPTION_TEXT_AREA | TUOPTION_PIC_AREA;
 					if( oldValue-scrollBar.view_recno >= 0 && oldValue-scrollBar.view_recno < MAX_BROWSE_DISP_REC)
 						refreshFlag |= TUOPTION_BROWSE(oldValue-scrollBar.view_recno);
+				}
+			}
+
+			if (mouse.right_press)
+			{
+				int status = scenInfoArray[browseRecno - 1].play_status;
+				status++;
+				if(status > nsPlayerStats::PlayStatus::COMPLETED)
+				{
+					status = nsPlayerStats::PlayStatus::UNPLAYED;
+				}
+				scenInfoArray[browseRecno - 1].play_status = status;
+				int browseSlotX1 = menuX1 + BROWSE_X1;
+				int browseSlotY1 = menuY1 + BROWSE_Y1 + (newValue - scrollBar.view_recno) * BROWSE_REC_HEIGHT;
+				draw_checkbox(browseSlotX1 + TEXT_OFFSET_X + 675,
+							  browseSlotY1 + TEXT_OFFSET_Y + 5,
+							  static_cast<CHECKBOX_STATE>(status));
+
+				// update PLAYSTAT.DAT
+				String path;
+				path += DIR_SCENARIO_PATH(scenInfoArray[browseRecno - 1].dir_id);;
+				path += scenInfoArray[browseRecno - 1].file_name;
+				char * internal_name = GameFile::read_internal_file_name(path);
+				if(internal_name)
+				{
+					playerStats.set_scenario_play_status(internal_name, static_cast<nsPlayerStats::PlayStatus>(status));
 				}
 			}
 		}

--- a/src/OGAMSCEN.cpp
+++ b/src/OGAMSCEN.cpp
@@ -43,7 +43,8 @@
 static void init_scenario_var(ScenInfo* scenInfo);
 static int sort_scenario_func(const void *arg1, const void *arg2);
 extern SaveGameInfo current_game_info; // After loading, need this to log it as played
-static nsPlayerStats::PlayerStats ps;
+using namespace nsPlayerStats;
+static PlayerStats ps;
 
 //---------- Begin of function Game::select_run_scenario ----------//
 //

--- a/src/OGAMSCEN.cpp
+++ b/src/OGAMSCEN.cpp
@@ -105,7 +105,7 @@ int Game::select_run_scenario()
 
 						// Get the internal name from the header for player stats tracking
 						{
-							playerStats.load_scenario_file(true);
+							playerStats.load_player_stats(true);
 							String path;
 							path = DIR_SCENARIO_PATH(dirId);
 							path += gameDir[i]->name;

--- a/src/OGAMSCEN.cpp
+++ b/src/OGAMSCEN.cpp
@@ -182,7 +182,7 @@ int Game::run_scenario(ScenInfo* scenInfo)
 			// ##### end Gilbert 1/11 #######//
 
 			if (current_game_info.game_name) {
-				ps.save_scenario_stat(current_game_info.game_name, PlayStatus::PLAYED);
+				ps.set_scenario_play_status(current_game_info.game_name, PlayStatus::PLAYED);
 			} else {
 				err.run("Scenario %s has no internal name\n", str);
 			}

--- a/src/OGAMSCEN.cpp
+++ b/src/OGAMSCEN.cpp
@@ -83,19 +83,6 @@ int Game::select_run_scenario()
 					scenInfoArray[scenInfoSize].file_name = gameDir[i]->name;    // keep the pointers to the file name string
 					scenInfoArray[scenInfoSize].dir_id    = dirId;
 
-					// Get the internal name from the header for player stats tracking
-					{
-						String str;
-						str = DIR_SCENARIO_PATH(dirId);
-						str += gameDir[i]->name;
-						char * internal_name = GameFile::read_internal_file_name((char*)str);
-						if (internal_name) 
-						{
-							PlayStatus status = ps.get_scenario_play_status(internal_name);
-							free(const_cast<char*>(internal_name));
-						}
-					}
-
 					{
 						misc.change_file_ext( txtFileName, gameDir[i]->name, "SCT" );
 
@@ -116,6 +103,19 @@ int Game::select_run_scenario()
 
 						fileTxtScen.get_token();		// skip "Bonus:"
 						scenInfoArray[scenInfoSize].goal_score_bonus = (short) fileTxtScen.get_num();
+
+						// Get the internal name from the header for player stats tracking
+						{
+							String path;
+							path = DIR_SCENARIO_PATH(dirId);
+							path += gameDir[i]->name;
+							char * internal_name = GameFile::read_internal_file_name((char*)path);
+							if (internal_name) {
+								PlayStatus status = ps.get_scenario_play_status(internal_name);
+								scenInfoArray[scenInfoSize].play_status = static_cast<int>(status);
+								free(const_cast<char*>(internal_name));
+							}
+						}
 					}
 				}
 			}

--- a/src/OGAMSCEN.cpp
+++ b/src/OGAMSCEN.cpp
@@ -44,7 +44,6 @@ static void init_scenario_var(ScenInfo* scenInfo);
 static int sort_scenario_func(const void *arg1, const void *arg2);
 extern SaveGameInfo current_game_info; // After loading, need this to log it as played
 using namespace nsPlayerStats;
-static PlayerStats ps;
 
 //---------- Begin of function Game::select_run_scenario ----------//
 //
@@ -106,12 +105,13 @@ int Game::select_run_scenario()
 
 						// Get the internal name from the header for player stats tracking
 						{
+							playerStats.load_scenario_file(true);
 							String path;
 							path = DIR_SCENARIO_PATH(dirId);
 							path += gameDir[i]->name;
 							char * internal_name = GameFile::read_internal_file_name((char*)path);
 							if (internal_name) {
-								PlayStatus status = ps.get_scenario_play_status(internal_name);
+								PlayStatus status = playerStats.get_scenario_play_status(internal_name);
 								scenInfoArray[scenInfoSize].play_status = static_cast<int>(status);
 								free(const_cast<char*>(internal_name));
 							}
@@ -182,7 +182,7 @@ int Game::run_scenario(ScenInfo* scenInfo)
 			// ##### end Gilbert 1/11 #######//
 
 			if (current_game_info.game_name) {
-				ps.set_scenario_play_status(current_game_info.game_name, PlayStatus::PLAYED);
+				playerStats.set_scenario_play_status(current_game_info.game_name, PlayStatus::PLAYED);
 			} else {
 				err.run("Scenario %s has no internal name\n", str);
 			}

--- a/src/OGFILE.cpp
+++ b/src/OGFILE.cpp
@@ -240,6 +240,28 @@ bool GameFile::read_header(const char* filePath, SaveGameInfo* /*out*/ saveGameI
 }
 //--------- End of function GameFile::read_header --------//
 
+//--------- Start of function GameFile::read_internal_file_name --------//
+//
+// Currently only used for scenario played-status tracking since the
+// internal file names aren't used/stored anywhere else but provide
+// a unique identifier for each scenario.
+//
+char * GameFile::read_internal_file_name(const char* filePath)
+{
+	char * ret = nullptr;
+	const int MAX_PATH = 260;
+	SaveGameHeader s;
+	if (read_header(filePath, &s.info)) {
+		int len = strnlen(s.info.game_name, MAX_PATH);
+		ret = (char*)calloc(1, len + 1);
+		if (ret) {
+			strncpy(ret, s.info.game_name, len);
+		}
+	}
+	
+	return ret;
+}
+//--------- End of function GameFile::read_internal_file_name --------//
 
 //-------- Begin of function GameFile::save_process -------//
 //

--- a/src/OSaveGameInfo.cpp
+++ b/src/OSaveGameInfo.cpp
@@ -26,12 +26,17 @@
 #include <OCONFIG.h>
 #include <OINFO.h>
 
+extern SaveGameInfo current_game_info; // in AM.cpp
 
 SaveGameInfo SaveGameInfoFromCurrentGame(const char* newFileName)
 {
 	SaveGameInfo saveGameInfo;
 
-	memset(saveGameInfo.file_name, 0, SaveGameInfo::MAX_FILE_PATH+1);
+	//
+	// Save the header-internal file/game name
+	//
+	memset(saveGameInfo.game_name, 0, SaveGameInfo::MAX_FILE_PATH+1);
+	strncpy(saveGameInfo.game_name, current_game_info.game_name, sizeof(current_game_info.game_name) - 1);
 
 	Nation* playerNation = ~nation_array;
 	strncpy( saveGameInfo.player_name, playerNation->king_name(), HUMAN_NAME_LEN );

--- a/src/OSaveGameProvider.cpp
+++ b/src/OSaveGameProvider.cpp
@@ -42,6 +42,8 @@
 #include <unistd.h>
 #endif
 
+extern SaveGameInfo current_game_info; // in AM.cpp
+
 DBGLOG_DEFAULT_CHANNEL(SaveGameProvider);
 
 
@@ -198,6 +200,10 @@ int SaveGameProvider::load_game_from_file(const char* filePath, SaveGameInfo* /*
 	const int powerEnableFlag = power.enable_flag;
 
 	int rc = GameFile::load_game(filePath, /*out*/ saveGameInfo);
+	if(rc)
+	{
+		memcpy(&current_game_info, saveGameInfo, sizeof(SaveGameInfo));
+	}
 
 	mouse_cursor.set_frame(0);		// to fix a frame bug with loading game
 

--- a/src/PlayerStats.cpp
+++ b/src/PlayerStats.cpp
@@ -1,0 +1,132 @@
+/*
+* Seven Kingdoms: Ancient Adversaries
+*
+* Copyright 2019 Steven Lavoie
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+//Filename    : PlayerStats.cpp
+//Description : Handles file IO for player statistics information
+
+#include <PlayerStats.h>
+#include <OSYS.h>
+
+using namespace player_stat_detail;
+extern Sys sys;
+
+PlayerStats::PlayerStats() {
+
+}
+
+PlayerStats::~PlayerStats() {
+	if (scene_stats) {
+		mem_del(scene_stats);
+		scene_stats = nullptr; // used as a flag later
+	}
+}
+
+FILE * PlayerStats::open_scenario_file(bool read) {
+	String filePath(sys.dir_config);
+	if (!misc.mkpath(sys.dir_config)) {
+		filePath += ".";
+	}
+
+	filePath += PATH_DELIM;
+	filePath += "scn_list.txt";
+	char * method = read ? "r" : "w";
+	return fopen(filePath, method);
+}
+
+bool PlayerStats::load_scenario_file() {
+	FILE *f = open_scenario_file(true);
+	if (!f) { return false; }
+
+	String line;
+	while (fgets(line, player_stat_detail::MAX_FILE_PATH, f)) {
+		int idx = scene_stats_len;
+		scene_stats_len++;
+		scene_stats = (ScenarioStats *)mem_resize(scene_stats, sizeof(ScenarioStats)*(scene_stats_len));
+		if (!scene_stats) { return false; }
+
+		strncpy(scene_stats[idx].internal_name, line, player_stat_detail::MAX_FILE_PATH);
+		int len = strnlen(scene_stats[idx].internal_name, player_stat_detail::MAX_FILE_PATH);
+		scene_stats[idx].internal_name[len - 1] = '\0'; //trim newline
+		fgets(line, 10, f);
+		char token = line[7];
+		int val = token - '0';
+		scene_stats[idx].status = static_cast<PlayStatus>(val);
+	}
+
+	fclose(f);
+	return true;
+}
+
+PlayStatus PlayerStats::get_scenario_play_status(char const * name) {
+	// Check if we already loaded our file. If not, do it.
+	if (!scene_stats) {
+		if (!load_scenario_file()) {
+			// Users just getting this new feature won't have the file,
+			// so we assume unplayed. A file will get created the first
+			// time they play a scenario.
+			return PlayStatus::UNPLAYED;
+		}
+	}
+
+	// Find a matching name and return its status
+	for (int i = 0; i < scene_stats_len; i++) {
+		if (!strncmp(scene_stats[i].internal_name, name, player_stat_detail::MAX_FILE_PATH)) {
+			return scene_stats[i].status;
+		}
+	}
+
+	// If the file failed to load or we don't have a 
+	// matching record, default to unplayed.
+	return PlayStatus::UNPLAYED;
+}
+
+bool PlayerStats::save_scenario_stat(char const * name, PlayStatus status) {
+	
+	bool found = false;
+	for (int i = 0; i < scene_stats_len; i++) {
+		if (!strncmp(scene_stats[i].internal_name, name, player_stat_detail::MAX_FILE_PATH)) {
+			scene_stats[i].status = status;
+			found = true;
+		}
+	}
+
+	if (!found) {
+		int idx = scene_stats_len;
+		scene_stats_len++;
+		scene_stats = (ScenarioStats *)mem_resize(scene_stats, sizeof(ScenarioStats)*(scene_stats_len));
+		strncpy(scene_stats[idx].internal_name, name, player_stat_detail::MAX_FILE_PATH);
+		scene_stats[idx].status = status;
+	}
+
+	//
+	// We re-write the entire file. If we get more scenarios or
+	// more data, this will need to just update an entry.
+	//
+	FILE *f = open_scenario_file(false);
+	if (!f) { return false; }
+	for (int i = 0; i < scene_stats_len; i++) {
+		fprintf(f, "%s\n", scene_stats[i].internal_name);	// write scenario name
+		fprintf(f, "Status:");								// write status token
+		fprintf(f, "%d\n", scene_stats[i].status);			// write status value
+		fclose(f);
+	}
+	
+	return true;
+}

--- a/src/PlayerStats.cpp
+++ b/src/PlayerStats.cpp
@@ -136,9 +136,9 @@ PlayStatus PlayerStats::get_scenario_play_status(char const * name) {
 }
 //------- End of function PlayerStats::get_scenario_play_status ------//
 
-//------- Begin of function PlayerStats::save_scenario_stat ------//
+//------- Begin of function PlayerStats::set_scenario_play_status ------//
 //
-bool PlayerStats::save_scenario_stat(char const * name, PlayStatus status) {
+bool PlayerStats::set_scenario_play_status(char const * name, PlayStatus status) {
 	for (int i = 0; i < scn_stat_arr_len; i++) {
 		if (!strncmp(scn_stat_arr[i].internal_name, name, detail::MAX_FILE_PATH)) {
 			if (scn_stat_arr[i].status != status) {
@@ -160,4 +160,4 @@ bool PlayerStats::save_scenario_stat(char const * name, PlayStatus status) {
 	scn_stat_arr[idx].status = status;
 	return write_scenario_file();
 }
-//------- End of function PlayerStats::save_scenario_stat ------//
+//------- End of function PlayerStats::set_scenario_play_status ------//

--- a/src/PlayerStats.cpp
+++ b/src/PlayerStats.cpp
@@ -24,71 +24,109 @@
 #include <PlayerStats.h>
 #include <OSYS.h>
 
-using namespace player_stat_detail;
-extern Sys sys;
+extern Sys sys;			// For the config directory
+using namespace nsPlayerStats;
+using namespace detail;
 
-PlayerStats::PlayerStats() {
 
-}
+//------- Begin of function PlayerStats::PlayerStats ------//
+//
+PlayerStats::PlayerStats() :
+	scn_stat_arr(nullptr),
+	scn_stat_arr_len(0) { }
+//------- End of function PlayerStats::PlayerStats ------//
 
+//------- Begin of function PlayerStats::~PlayerStats ------//
+//
 PlayerStats::~PlayerStats() {
-	if (scene_stats) {
-		mem_del(scene_stats);
-		scene_stats = nullptr; // used as a flag later
+	if (scn_stat_arr) {
+		mem_del(scn_stat_arr);
+		scn_stat_arr = nullptr; // used as a flag later
 	}
 }
+//------- End of function PlayerStats::~PlayerStats ------//
 
-FILE * PlayerStats::open_scenario_file(bool read) {
-	String filePath(sys.dir_config);
-	if (!misc.mkpath(sys.dir_config)) {
-		filePath += ".";
-	}
-
-	filePath += PATH_DELIM;
-	filePath += "scn_list.txt";
-	char * method = read ? "r" : "w";
-	return fopen(filePath, method);
-}
-
+//------- Begin of function PlayerStats::load_scenario_file ------//
+//
 bool PlayerStats::load_scenario_file() {
-	FILE *f = open_scenario_file(true);
-	if (!f) { return false; }
+	FilePath full_path(sys.dir_config);
+	int  rc;
+	File file;
 
-	String line;
-	while (fgets(line, player_stat_detail::MAX_FILE_PATH, f)) {
-		int idx = scene_stats_len;
-		scene_stats_len++;
-		scene_stats = (ScenarioStats *)mem_resize(scene_stats, sizeof(ScenarioStats)*(scene_stats_len));
-		if (!scene_stats) { return false; }
+	full_path += scn_dat_file;
+	if (full_path.error_flag)
+		return 0;
 
-		strncpy(scene_stats[idx].internal_name, line, player_stat_detail::MAX_FILE_PATH);
-		int len = strnlen(scene_stats[idx].internal_name, player_stat_detail::MAX_FILE_PATH);
-		scene_stats[idx].internal_name[len - 1] = '\0'; //trim newline
-		fgets(line, 10, f);
-		char token = line[7];
-		int val = token - '0';
-		scene_stats[idx].status = static_cast<PlayStatus>(val);
+	if (!misc.is_file_exist(full_path))
+		return 0;
+
+	rc = file.file_open(full_path, 0, 1);   // 0=don't handle error itself
+											// 1=allow the writing size and the read size to be different
+	if (!rc)
+		return false;
+	// 1=allow the writing size and the read size to be different
+	//--------- Read Hall of Fame ----------//
+
+	if (rc) {
+		scn_stat_arr_len = file.file_get_long();
 	}
 
-	fclose(f);
-	return true;
-}
+	if (rc && scn_stat_arr_len) {
+		scn_stat_arr = (ScenStat *)mem_add_clear(sizeof(ScenStat)*(scn_stat_arr_len));
+		rc = file.file_read(scn_stat_arr, sizeof(ScenStat) * scn_stat_arr_len);
+	}
 
+	file.file_close();
+	return rc == 1 ? true : false;
+}
+//------- End of function PlayerStats::load_scenario_file ------//
+
+//------- Begin of function PlayerStats::write_scenario_file ------//
+//
+// Will re-write the entire file with values from scn_stat_arr
+//
+bool PlayerStats::write_scenario_file() {
+
+	FilePath full_path(sys.dir_config);
+	full_path += scn_dat_file;
+	if (full_path.error_flag)
+		return 0;
+
+	File file;
+	int rc = file.file_create(full_path, 0, 1);  // 0=don't handle error itself
+
+	if (!rc) { return false; }
+
+
+	if (rc) {
+		rc = file.file_put_long(scn_stat_arr_len);
+	}
+
+	if (rc) {
+		rc = file.file_write(scn_stat_arr, sizeof(ScenStat) * scn_stat_arr_len);
+	}
+
+	file.file_close();
+	return rc == 1 ? true : false;
+}
+//------- End of function PlayerStats::write_scenario_file ------//
+
+//------- Begin of function PlayerStats::get_scenario_play_status ------//
+//
 PlayStatus PlayerStats::get_scenario_play_status(char const * name) {
 	// Check if we already loaded our file. If not, do it.
-	if (!scene_stats) {
+	if (!scn_stat_arr) {
 		if (!load_scenario_file()) {
-			// Users just getting this new feature won't have the file,
-			// so we assume unplayed. A file will get created the first
-			// time they play a scenario.
+			// New installs won't have the file, so we assume unplayed. The
+			// file will get created the first time they play a scenario.
 			return PlayStatus::UNPLAYED;
 		}
 	}
 
 	// Find a matching name and return its status
-	for (int i = 0; i < scene_stats_len; i++) {
-		if (!strncmp(scene_stats[i].internal_name, name, player_stat_detail::MAX_FILE_PATH)) {
-			return scene_stats[i].status;
+	for (int i = 0; i < scn_stat_arr_len; i++) {
+		if (!strncmp(scn_stat_arr[i].internal_name, name, detail::MAX_FILE_PATH)) {
+			return scn_stat_arr[i].status;
 		}
 	}
 
@@ -96,37 +134,30 @@ PlayStatus PlayerStats::get_scenario_play_status(char const * name) {
 	// matching record, default to unplayed.
 	return PlayStatus::UNPLAYED;
 }
+//------- End of function PlayerStats::get_scenario_play_status ------//
 
+//------- Begin of function PlayerStats::save_scenario_stat ------//
+//
 bool PlayerStats::save_scenario_stat(char const * name, PlayStatus status) {
-	
-	bool found = false;
-	for (int i = 0; i < scene_stats_len; i++) {
-		if (!strncmp(scene_stats[i].internal_name, name, player_stat_detail::MAX_FILE_PATH)) {
-			scene_stats[i].status = status;
-			found = true;
+	for (int i = 0; i < scn_stat_arr_len; i++) {
+		if (!strncmp(scn_stat_arr[i].internal_name, name, detail::MAX_FILE_PATH)) {
+			if (scn_stat_arr[i].status != status) {
+				// Update the entry and re-write the file
+				scn_stat_arr[i].status = status;
+				return write_scenario_file();
+			} else {
+				// Don't bother writing to the file if no change is needed
+				return true;
+			}
 		}
 	}
 
-	if (!found) {
-		int idx = scene_stats_len;
-		scene_stats_len++;
-		scene_stats = (ScenarioStats *)mem_resize(scene_stats, sizeof(ScenarioStats)*(scene_stats_len));
-		strncpy(scene_stats[idx].internal_name, name, player_stat_detail::MAX_FILE_PATH);
-		scene_stats[idx].status = status;
-	}
-
-	//
-	// We re-write the entire file. If we get more scenarios or
-	// more data, this will need to just update an entry.
-	//
-	FILE *f = open_scenario_file(false);
-	if (!f) { return false; }
-	for (int i = 0; i < scene_stats_len; i++) {
-		fprintf(f, "%s\n", scene_stats[i].internal_name);	// write scenario name
-		fprintf(f, "Status:");								// write status token
-		fprintf(f, "%d\n", scene_stats[i].status);			// write status value
-		fclose(f);
-	}
-	
-	return true;
+	// If we get here, there was no entry so we need a new one
+	int idx = scn_stat_arr_len;
+	scn_stat_arr_len++;
+	scn_stat_arr = (ScenStat *)mem_resize(scn_stat_arr, sizeof(ScenStat)*(scn_stat_arr_len));
+	strncpy(scn_stat_arr[idx].internal_name, name, detail::MAX_FILE_PATH);
+	scn_stat_arr[idx].status = status;
+	return write_scenario_file();
 }
+//------- End of function PlayerStats::save_scenario_stat ------//

--- a/src/PlayerStats.cpp
+++ b/src/PlayerStats.cpp
@@ -113,7 +113,7 @@ bool PlayerStats::write_scenario_file() {
 
 //------- Begin of function PlayerStats::get_scenario_play_status ------//
 //
-PlayStatus PlayerStats::get_scenario_play_status(char const * name) {
+PlayStatus PlayerStats::get_scenario_play_status(char const * internal_name) {
 	// Check if we already loaded our file. If not, do it.
 	if (!scn_stat_arr) {
 		if (!load_scenario_file()) {
@@ -125,7 +125,7 @@ PlayStatus PlayerStats::get_scenario_play_status(char const * name) {
 
 	// Find a matching name and return its status
 	for (int i = 0; i < scn_stat_arr_len; i++) {
-		if (!strncmp(scn_stat_arr[i].internal_name, name, detail::MAX_FILE_PATH)) {
+		if (!strncmp(scn_stat_arr[i].internal_name, internal_name, detail::MAX_FILE_PATH)) {
 			return scn_stat_arr[i].status;
 		}
 	}


### PR DESCRIPTION
Re: #52 
Hopefully I cherry-picked this right. I think I've worked out all the kinks so take a look and let me know what you think. There are a couple hack-ish things (some constantly re-used values like MAX_FILE_PATH that aren't globals) but those are across the code so I didn't touch those yet.

You can right-click on a scenario to cycle through the various checkboxes, allowing you to set/reset a particular scenario manually. Other than that, they're marked as played as soon as you launch one and marked complete if you finish a game without retiring.

This could probably be expanded to track training scenarios pretty easily too.