### PR TITLE
fix to not change screen when clicking on smaller quantity button

### DIFF
--- a/src/OF_WAR.cpp
+++ b/src/OF_WAR.cpp
@@ -369,11 +369,7 @@ void FirmWar::detect_build_menu()
 
 			if( quitFlag )
 				info.disp();		// info.disp() will call put_info() which will switch mode back to the main menu mode
-			// ###### begin Gilbert 10/9 ########//
-			else
-				//disp_queue_button(y+COUNT_BUTTON_OFFSET_Y, unitId, 1);
-				info.update();
-			// ###### end Gilbert 10/9 ########//
+			
 
 			return;
 		}


### PR DESCRIPTION
Problem: when in the "make a weapon" screen of a war factory, if the smaller build quantity button is clicked the quantity should increase by one and remain on the same screen. Currently, the quantity increases but the screen returns to the main war factory screen.

I was able to resolve the issue by removing the call to `info.update` if the `quitFlag` is not set as indicated in the patch. I did not experience any further side effects but would be interested in your feedback.