### PR TITLE
Use file name for scenario play status tracking

### DIFF
--- a/include/OGFILE.h
+++ b/include/OGFILE.h
@@ -41,8 +41,6 @@ public:
 
    // Reads the given file and fills the save game info from the header. Returns true if successful.
    static bool read_header(const char* filePath, SaveGameInfo* /*out*/ saveGameInfo);
-   // Reads the internal file name stored in the header. Returns null on failure.
-   static char * read_internal_file_name(const char* filePath);
    static const char *status_str();
 
 public:

--- a/include/PlayerStats.h
+++ b/include/PlayerStats.h
@@ -70,11 +70,11 @@ struct ScenStat {
 	// an 8.3 filename, we'll dispense with the extra byte. Windows includes /0 in
 	// its MAX_PATH's 260 bytes anyway.
 	//
-	char internal_name[MAX_FILE_PATH];
+	char game_name[MAX_FILE_PATH];
 	PlayStatus status;
 };
 
-static_assert(sizeof(ScenStat::internal_name) == MAX_FILE_PATH, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");
+static_assert(sizeof(ScenStat::game_name) == MAX_FILE_PATH, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");
 static_assert(sizeof(ScenStat) == 264, "Changing ScenStat is a breaking change for PLAYSTAT.DAT");
 
 }
@@ -88,8 +88,8 @@ private:
 	bool write_player_stats();
 
 public:
-	PlayStatus get_scenario_play_status(char const * name);
-	bool set_scenario_play_status(char const * name, PlayStatus status);
+	PlayStatus get_scenario_play_status(char const * game_name);
+	bool set_scenario_play_status(char const * game_name, PlayStatus status);
 	// If force_reload==true, the stats will be reloaded from the file or,
 	// if the file is deleted, the UI will be updated to reflect that
 	bool load_player_stats(bool force_reload = false);

--- a/src/OGAMSCE2.cpp
+++ b/src/OGAMSCE2.cpp
@@ -587,11 +587,7 @@ int Game::select_scenario(int scenCount, ScenInfo* scenInfoArray)
 				String path;
 				path += DIR_SCENARIO_PATH(scenInfoArray[browseRecno - 1].dir_id);;
 				path += scenInfoArray[browseRecno - 1].file_name;
-				char * internal_name = GameFile::read_internal_file_name(path);
-				if(internal_name)
-				{
-					playerStats.set_scenario_play_status(internal_name, static_cast<nsPlayerStats::PlayStatus>(status));
-				}
+				playerStats.set_scenario_play_status(scenInfoArray[browseRecno - 1].file_name, static_cast<nsPlayerStats::PlayStatus>(status));
 			}
 		}
 		// ######## begin Gilbert 1/11 #########//

--- a/src/OGAMSCEN.cpp
+++ b/src/OGAMSCEN.cpp
@@ -109,12 +109,8 @@ int Game::select_run_scenario()
 							String path;
 							path = DIR_SCENARIO_PATH(dirId);
 							path += gameDir[i]->name;
-							char * internal_name = GameFile::read_internal_file_name((char*)path);
-							if (internal_name) {
-								PlayStatus status = playerStats.get_scenario_play_status(internal_name);
-								scenInfoArray[scenInfoSize].play_status = static_cast<int>(status);
-								free(const_cast<char*>(internal_name));
-							}
+							PlayStatus status = playerStats.get_scenario_play_status(gameDir[i]->name);
+							scenInfoArray[scenInfoSize].play_status = static_cast<int>(status);
 						}
 					}
 				}

--- a/src/OGFILE.cpp
+++ b/src/OGFILE.cpp
@@ -240,29 +240,6 @@ bool GameFile::read_header(const char* filePath, SaveGameInfo* /*out*/ saveGameI
 }
 //--------- End of function GameFile::read_header --------//
 
-//--------- Start of function GameFile::read_internal_file_name --------//
-//
-// Currently only used for scenario played-status tracking since the
-// internal file names aren't used/stored anywhere else but provide
-// a unique identifier for each scenario.
-//
-char * GameFile::read_internal_file_name(const char* filePath)
-{
-	char * ret = nullptr;
-	const int MAX_PATH = 260;
-	SaveGameHeader s;
-	if (read_header(filePath, &s.info)) {
-		int len = strnlen(s.info.game_name, MAX_PATH);
-		ret = (char*)calloc(1, len + 1);
-		if (ret) {
-			strncpy(ret, s.info.game_name, len);
-		}
-	}
-	
-	return ret;
-}
-//--------- End of function GameFile::read_internal_file_name --------//
-
 //-------- Begin of function GameFile::save_process -------//
 //
 // Make the game data ready for saving game

--- a/src/OSaveGameProvider.cpp
+++ b/src/OSaveGameProvider.cpp
@@ -42,7 +42,9 @@
 #include <unistd.h>
 #endif
 
-extern SaveGameInfo current_game_info; // in AM.cpp
+// Both in AM.cpp
+extern Misc misc;
+extern SaveGameInfo current_game_info;
 
 DBGLOG_DEFAULT_CHANNEL(SaveGameProvider);
 
@@ -180,7 +182,14 @@ int SaveGameProvider::load_game(const char* fileName, SaveGameInfo* /*out*/ save
 int SaveGameProvider::load_scenario(const char* filePath)
 {
 	SaveGameInfo saveGameInfo;
-	return load_game_from_file(filePath, /*out*/ &saveGameInfo);
+	auto rc = load_game_from_file(filePath, /*out*/ &saveGameInfo);
+	// Note that saveGameInfo is just thrown away here, so we're writing
+	// to the global current_game_info instead. This is necessary because
+	// the internal name field is not unique across all the original game
+	// scenario files. Since the actual file names are, we're using those
+	// to uniquely identify each game.
+	misc.extract_file_name(current_game_info.game_name, filePath);
+	return rc;
 }
 //-------- End of function SaveGameProvider::load_scenario --------//
 

--- a/src/PlayerStats.cpp
+++ b/src/PlayerStats.cpp
@@ -136,7 +136,7 @@ bool PlayerStats::write_player_stats() {
 
 //------- Begin of function PlayerStats::get_scenario_play_status ------//
 //
-PlayStatus PlayerStats::get_scenario_play_status(char const * internal_name) {
+PlayStatus PlayerStats::get_scenario_play_status(char const * game_name) {
 	// Check if we already loaded our file. If not, do it.
 	if (!scn_stat_arr) {
 		if (!load_player_stats()) {
@@ -148,7 +148,7 @@ PlayStatus PlayerStats::get_scenario_play_status(char const * internal_name) {
 
 	// Find a matching name and return its status
 	for (int i = 0; i < scn_stat_arr_len; i++) {
-		if (!strncmp(scn_stat_arr[i].internal_name, internal_name, detail::MAX_FILE_PATH)) {
+		if (!strncmp(scn_stat_arr[i].game_name, game_name, detail::MAX_FILE_PATH)) {
 			return scn_stat_arr[i].status;
 		}
 	}
@@ -161,7 +161,7 @@ PlayStatus PlayerStats::get_scenario_play_status(char const * internal_name) {
 
 //------- Begin of function PlayerStats::set_scenario_play_status ------//
 //
-bool PlayerStats::set_scenario_play_status(char const * name, PlayStatus status) {
+bool PlayerStats::set_scenario_play_status(char const * game_name, PlayStatus status) {
 	// Check if we already loaded our file. If not, do it.
 	if (!scn_stat_arr) {
 		// If it fails, we'll create a new one. If it succeeds, we'll
@@ -170,7 +170,7 @@ bool PlayerStats::set_scenario_play_status(char const * name, PlayStatus status)
 	}
 
 	for (int i = 0; i < scn_stat_arr_len; i++) {
-		if (!strncmp(scn_stat_arr[i].internal_name, name, detail::MAX_FILE_PATH)) {
+		if (!strncmp(scn_stat_arr[i].game_name, game_name, detail::MAX_FILE_PATH)) {
 			if (scn_stat_arr[i].status != status) {
 				// Update the entry and re-write the file
 				scn_stat_arr[i].status = status;
@@ -186,7 +186,7 @@ bool PlayerStats::set_scenario_play_status(char const * name, PlayStatus status)
 	int idx = scn_stat_arr_len;
 	scn_stat_arr_len++;
 	scn_stat_arr = (ScenStat *)mem_resize(scn_stat_arr, sizeof(ScenStat)*(scn_stat_arr_len));
-	strncpy(scn_stat_arr[idx].internal_name, name, detail::MAX_FILE_PATH);
+	strncpy(scn_stat_arr[idx].game_name, game_name, detail::MAX_FILE_PATH);
 	scn_stat_arr[idx].status = status;
 	return write_player_stats();
 }


### PR DESCRIPTION
Fixes the issue discussed in #118.

The SAV file's internal name field was not kept unique across all
of the game's original scenario files so load_scenario() now overwrites
that field with the actual file name. We can't use the file_name field
since that will no longer match once a game has been saved/reloaded.

(cherry picked from commit 395f6d20be74c6010a95aaac4a58194d0faa0063)