### PR TITLE
[WIP] Expose is_retail_market Flag to Users

### DIFF
--- a/data/RESOURCE/HELP.RES
+++ b/data/RESOURCE/HELP.RES
@@ -78,6 +78,10 @@ CHGPROD
 Change Production
 This toggles production in this factory between iron, copper, and clay products.
 ~
+MKTYPE
+Market Type
+This toggles the resources prioritized at this market between raw and finished products, or either. An unprioritized resource taking up a slot but with 0 for the amount will auto-clear for a prioritized resource that becomes available.
+~
 COLLTAX
 Collect Tax
 This collects tax from the selected village. If you right-click on this, you will be able to tax your villagers automatically.

--- a/include/OF_MARK.h
+++ b/include/OF_MARK.h
@@ -84,6 +84,9 @@ struct FirmMarketCrc;
 #pragma pack(1)
 class FirmMarket : public Firm
 {
+private:
+	char *      	 market_type = "retail";
+
 public:
 	float			 max_stock_qty;		// maximum stock qty of each market goods
 
@@ -117,7 +120,8 @@ public:
 	void		next_day();
 	void		next_month();
 	void		next_year();
-
+	
+	void		change_market_type();
 	void		sell_goods();
 	short		hire_caravan(char remoteAction);
 	int		can_hire_caravan();

--- a/src/OU_CARAT.cpp
+++ b/src/OU_CARAT.cpp
@@ -216,10 +216,14 @@ int UnitCaravan::market_unload_goods_in_empty_slot(FirmMarket *curMarket, int po
 		processed_product_raw_qty_array[j] += 2;
 		curMarket->set_goods(0, j+1, position);
 
-		short unloadQty = (short) MIN(product_raw_qty_array[j], curMarket->max_stock_qty-marketGoods->stock_qty);
-		product_raw_qty_array[j] -= unloadQty;
-		marketGoods->stock_qty	 += unloadQty;
-		processed++;
+		if (curMarket->is_retail_market)
+		{
+			short unloadQty = (short)MIN(product_raw_qty_array[j], curMarket->max_stock_qty - marketGoods->stock_qty);
+			product_raw_qty_array[j] -= unloadQty;
+			marketGoods->stock_qty += unloadQty;
+			processed++;
+		}
+
 		break;
 	}
 
@@ -269,10 +273,14 @@ int UnitCaravan::market_unload_goods_in_empty_slot(FirmMarket *curMarket, int po
 			processed_raw_qty_array[j] += 2;
 			curMarket->set_goods(1, j+1, position);
 
-			short unloadQty = (short) MIN(raw_qty_array[j], curMarket->max_stock_qty-marketGoods->stock_qty);
-			raw_qty_array[j]			-= unloadQty;
-			marketGoods->stock_qty	+= unloadQty;
-			processed++;
+			if (!curMarket->is_retail_market)
+			{
+				short unloadQty = (short)MIN(raw_qty_array[j], curMarket->max_stock_qty - marketGoods->stock_qty);
+				raw_qty_array[j] -= unloadQty;
+				marketGoods->stock_qty += unloadQty;
+				processed++;
+			}
+
 			break;
 		}
 	}


### PR DESCRIPTION
_This is a draft PR, hopefully to facilitate contributions and conversation._

I re-did the work originally posted in #58, in case anyone wants to continue tinkering. It's rebased on the latest master (i.e., not on my Visual Studio branch) so it'll be easier to get started.

There are a couple immediate issues:

1. Should we just re-use the factory's "Change Production" button? I do for now. We could just a checkbox instead, or make a new button.
2. How do we identify the current setting? It's a plaintext kludge right now. A checkbox would make this easy.
3. Auto-clearing a product in favor of a new drop-off doesn't work as proactively as it should. I haven't really looked into it yet.

How it works: 

Caravans, mines, and factories will not deposit goods that don't match the current market type. Any product at `0` will be automatically cleared if another good that matches the current state (raw vs finished) comes from a factory/caravan. So, for example, if finished iron goods is at `0` in a "raw" market and a caravan shows up with raw copper, the finished iron slot will be cleared so the raw copper can be deposited.

