### PR TITLE
Add inputenc to fix rendering UTF8 character

### DIFF
--- a/doc/main.tex
+++ b/doc/main.tex
@@ -107,6 +107,7 @@
 
 \documentclass[openany]{book}
 \usepackage[paperwidth=5.51in, paperheight=8.81in, top=0.6205in, bottom=1.005in, right=0.505in, left=0.705in,]{geometry} % From the original manual. Do not change.
+\usepackage[utf8]{inputenc} % Now we can write UTF8 characters directly in the .tex files
 \usepackage[T1]{fontenc} % T1 accanthis specific?
 \usepackage{accanthis} % Main font.
 \usepackage{yfonts} % ygothic: For first paragraphs.


### PR DESCRIPTION
Some characters did not render properly (at least on pdflatex and on my system) because while they were written correctly in the source files (such as ø in Bjørn Lynne), by default LaTeX does not support anything but ASCII.

One choice is to fix all these UTF8 characters with a code that will render them (e.g. `\o{}` will render as ø). The other option is to load the package *inputenc*, which for some reason was missing (the opposite package that renders these symbols is called *fontenc* and is already loaded).

For more information, see: https://en.wikibooks.org/wiki/LaTeX/Special_Characters

Note that this might have hide some special characters that just look like normal letters but aren't. I have previously saw that there was some snafu around Balista. This fix does not solve the source of the error, but merely hide it so it is not visible in the manual. I think that trying to fix every special character that might have gotten into the source would be a lot of work and this does sufficiently solve the visible problem. Every non-standard characters can be fixed later when they become problem again (or when editing their local area).


I have went through the whole PDF to look if there is any special character that does not render properly, but couldn't find any, so I think this is a good fix.