### PR TITLE
Reworked headings/titles.

### DIFF
--- a/doc/main.tex
+++ b/doc/main.tex
@@ -154,7 +154,8 @@ Seven Kingdoms: Ancient Adversaries OSS Project} % Do not change.
 \frontmatter
 \maketitle
 
-\section{Copyright Notice}
+\pdfbookmark{Copyright Notice}{CopyrightNotice}
+\section*{Copyright Notice}
 
 Seven Kingdoms: Ancient Adversaries Instruction Manual
 
@@ -166,21 +167,22 @@ This manual is distributed in the hope that it will be useful, but WITHOUT ANY W
 
 You should have received a copy of the GNU General Public License along with this manual.  If not, see <http://www.gnu.org/licenses/>.
 
-\subsection{Other Copyright}
+\subsection*{Other Copyright}
 
-\subsubsection{Music}
+\subsubsection*{Music}
 
 % ø letter and (c)
 
 The music is the work of Bjørn Lynne, Copyright (c) 1997, and is not provided under the GPL. It may be freely downloaded and used with Seven Kingdoms: Ancient Adversaries but not modified or repurposed into derivative works.
 
-\subsubsection{Trademark}
+\subsubsection*{Trademark}
 
 Seven Kingdoms is a trademark of Enlight Software Ltd., and the 7kfans project is using the trademark with permission. This license does not constitute a transfer of any ownership, rights, or authority to the trademarks owned by Enlight. Any questions regarding use must be directed to Enlight.
 
 \clearpage
 
-\section{Project Introduction}
+\pdfbookmark{Project Introduction}{ProjectIntroduction}
+\section*{Project Introduction}
 
 % Hyphenation here
 
@@ -192,16 +194,21 @@ The official website for \textit{Seven Kingdoms: Ancient Adversaries} OSS Projec
 
 This manual is part of the community project. It has been updated to reflect the current status of \textit{Seven Kingdoms: Ancient Adversaries}.
 
-\section{Registration}
+
+\pdfbookmark{Registration}{Registration}
+\section*{Registration}
 
 \index{registering}
 
 \textgoth{\Huge{R}}egister for a forums account. An account is necessary to post on the forums, use the mChat feature, and to play using the 7kfans.com multiplayer service.
 
-\section{Questions or Problems}
+\pdfbookmark{Questions or Problems}{QuestionsOrProblems}
+\section*{Questions or Problems}
 
 \textgoth{\Huge{I}}f you have difficulties with this game and cannot find the solution in this manual, there is additional information on the wiki, or post your question or problem on the forums for assistance from a member of the community.
 
+\clearpage
+\pdfbookmark{\contentsname}{Contents}
 \tableofcontents
 
 \mainmatter

--- a/doc/main.tex
+++ b/doc/main.tex
@@ -130,6 +130,16 @@
     \fancyhf[lh,rh,ch]{}
     \fancyhf[leh]{\leftmark}
     \fancyhf[roh]{\rightmark}
+\usepackage{titlesec} % For modification of titles
+% \titlespacing\command{left}{before}{after}
+% spacing: how to read {12pt plus 4pt minus 2pt}
+%           12pt is what we would like the spacing to be
+%           plus 4pt means that TeX can stretch it by at most 4pt
+%           minus 2pt means that TeX can shrink it by at most 2pt
+\titlespacing\section{0pt}{12pt plus 4pt minus 2pt}{-4pt plus 6pt minus 2pt}
+\titlespacing\subsection{0pt}{12pt plus 4pt minus 2pt}{-4pt plus 6pt minus 2pt}
+\titlespacing\subsubsection{0pt}{12pt plus 4pt minus 2pt}{-4pt plus 6pt minus 2pt}
+
 \usepackage{makeidx} % Index
     \makeindex
 \usepackage[hidelinks]{hyperref} % For the index and TOC but not for external links. Non color, frameless links from the original manual.

--- a/doc/main.tex
+++ b/doc/main.tex
@@ -107,24 +107,33 @@
 
 \documentclass[openany]{book}
 \usepackage[paperwidth=5.51in, paperheight=8.81in, top=0.6205in, bottom=1.005in, right=0.505in, left=0.705in,]{geometry} % From the original manual. Do not change.
-\usepackage[T1]{fontenc} % T1 accanthis specific?
+
+% Fonts:
+\usepackage[T1]{fontenc} % T1 fonts are 8 bit fonts with a large amount of glyphs
 \usepackage{accanthis} % Main font.
 \usepackage{yfonts} % ygothic: For first paragraphs.
-\usepackage{xcolor,colortbl} % Need both?
-\usepackage{graphicx}
+
+% Graphics, figures and tables:
+\usepackage{graphicx} % Basic support for figures
 \graphicspath{{assets/}}
-\usepackage[hidelinks]{hyperref} % For the index and TOC but not for external links. Non color, frameless links from the original manual.
-\usepackage{wrapfig}
-\usepackage{tabu}
-\usepackage{fancyhdr}
+\usepackage{wrapfig} % Wrap figure around text
+\usepackage{xcolor} % An extended support for colors, required by tabu
+\usepackage{colortbl} % Pretty colored tables, required by tabu
+\usepackage{longtable} % for long tables spanning multiple pages, required by tabu
+\usepackage{tabu} % for any sort of tables, unifies other environments into tabu and longtabu, but does not load required packages
+
+% Miscellaneous 
+\usepackage{fancyhdr} % An extended support for fancy headers and footers
     \pagestyle{fancy}
     \setlength{\headheight}{22.44pt} % 22.44pt used to avoid errors.
     \renewcommand{\headrulewidth}{.5pt} % From original manual?
     \fancyhf[lh,rh,ch]{}
     \fancyhf[leh]{\leftmark}
     \fancyhf[roh]{\rightmark}
-\usepackage{makeidx}
+\usepackage{makeidx} % Index
     \makeindex
+\usepackage[hidelinks]{hyperref} % For the index and TOC but not for external links. Non color, frameless links from the original manual.
+
 
 %\usepackage{showframe} % For testing.
 

--- a/doc/main.tex
+++ b/doc/main.tex
@@ -130,20 +130,39 @@
     \fancyhf[lh,rh,ch]{}
     \fancyhf[leh]{\leftmark}
     \fancyhf[roh]{\rightmark}
-\usepackage{titlesec} % For modification of titles
+\usepackage[explicit]{titlesec} % For modification of titles
 % \titlespacing\command{left}{before}{after}
 % spacing: how to read {12pt plus 4pt minus 2pt}
 %           12pt is what we would like the spacing to be
 %           plus 4pt means that TeX can stretch it by at most 4pt
 %           minus 2pt means that TeX can shrink it by at most 2pt
+\titlespacing\chapter{0pt}{12pt plus 4pt minus 2pt}{12pt plus 6pt minus 2pt}
 \titlespacing\section{0pt}{12pt plus 4pt minus 2pt}{-4pt plus 6pt minus 2pt}
 \titlespacing\subsection{0pt}{12pt plus 4pt minus 2pt}{-4pt plus 6pt minus 2pt}
 \titlespacing\subsubsection{0pt}{12pt plus 4pt minus 2pt}{-4pt plus 6pt minus 2pt}
+\titleformat%
+    {\chapter}% command
+    [display]% shape, one of: hang, block, display, runin, leftmargin, rightmargin, drop, wrap, frame
+    {\bfseries\Huge}% format
+    {\fontsize{40}{40}\selectfont\thechapter}% label
+    {0em}% sep
+    {
+        \vspace{-1.5em}
+        \hspace{1.5em}
+        \parbox{0.8\textwidth}{
+            \raggedright%
+            #1%
+        }
+    }% before-code
+    [
+        \vspace{0.1em}
+        \titlerule
+    ]% after-code
+
 
 \usepackage{makeidx} % Index
     \makeindex
 \usepackage[hidelinks]{hyperref} % For the index and TOC but not for external links. Non color, frameless links from the original manual.
-
 
 %\usepackage{showframe} % For testing.
 


### PR DESCRIPTION
This PR does four things:

- A large amount of empty space around titles is reduced.
- The sections in preface/frontmatter are changed from numbered to unnumbered, but their presence in the TOC is preserved
- The chapter starts are reworked to be closer to the original manual and reduce the blank space
- Small rework of inputs with explanation what individual packages do.