### PR TITLE
Update main menu drawing and functions

### DIFF
--- a/include/OBUTTCUS.h
+++ b/include/OBUTTCUS.h
@@ -82,7 +82,7 @@ public:
 
 	void disable()     { if(enable_flag)  { enable_flag=0; paint(); } }
 	void enable()      { if(!enable_flag) { enable_flag=1; paint(); } }
-
+	bool detect_hover();
 	static void disp_text_button_func(ButtonCustom *, int repaintBody);
 
 };

--- a/include/OGAME.h
+++ b/include/OGAME.h
@@ -79,6 +79,11 @@ struct ScenInfo
 	int		play_status;
 };
 
+struct OptionInfo
+{
+	short x1, y1, x2, y2;
+};
+
 //-------- Define class Game -----------//
 
 struct Location;
@@ -160,6 +165,8 @@ private:
 	int			mp_select_session();
 	void			mp_disp_players();
 	int			mp_select_load_option(char *);
+	char *get_bitmap_by_name(const char *bitmap_name);
+	void update_main_menu_button(int x, int y, OptionInfo menu_button, char * bitmap);
 };
 #pragma pack()
 

--- a/include/OGAME.h
+++ b/include/OGAME.h
@@ -100,7 +100,7 @@ public:
 	char			started_flag;
 	char			game_mode;
 	char			game_has_ended;		// whether game_end() has been called once already and the player is now just staying in the game to continue to play or observe
-	ButtonCustom main_menu_button_list[MAIN_OPTION_COUNT];
+	// ButtonCustom main_menu_button_list[MAIN_OPTION_COUNT];
 	//-------- color remap info -------//
 
 	ColorRemap	color_remap_array[MAX_COLOR_SCHEME+1];
@@ -168,7 +168,6 @@ private:
 	int			mp_select_session();
 	void			mp_disp_players();
 	int			mp_select_load_option(char *);
-	void update_main_menu_button(int x, int y, OptionInfo menu_button, char * bitmap);
 };
 #pragma pack()
 

--- a/include/OGAME.h
+++ b/include/OGAME.h
@@ -93,7 +93,6 @@ public:
 	char			started_flag;
 	char			game_mode;
 	char			game_has_ended;		// whether game_end() has been called once already and the player is now just staying in the game to continue to play or observe
-	// ButtonCustom main_menu_button_list[MAIN_OPTION_COUNT];
 	//-------- color remap info -------//
 
 	ColorRemap	color_remap_array[MAX_COLOR_SCHEME+1];

--- a/include/OGAME.h
+++ b/include/OGAME.h
@@ -80,13 +80,6 @@ struct ScenInfo
 	int		play_status;
 };
 
-struct OptionInfo
-{
-	short x1, y1, x2, y2;
-};
-
-enum { MAIN_OPTION_COUNT = 6 };
-
 //-------- Define class Game -----------//
 
 struct Location;

--- a/include/OGAME.h
+++ b/include/OGAME.h
@@ -26,6 +26,7 @@
 
 #include <ALL.h>
 #include <OCONFIG.h>
+#include <OBUTTCUS.h>
 
 //-------- Define game modes -----------//
 
@@ -84,6 +85,8 @@ struct OptionInfo
 	short x1, y1, x2, y2;
 };
 
+enum { MAIN_OPTION_COUNT = 6 };
+
 //-------- Define class Game -----------//
 
 struct Location;
@@ -97,7 +100,7 @@ public:
 	char			started_flag;
 	char			game_mode;
 	char			game_has_ended;		// whether game_end() has been called once already and the player is now just staying in the game to continue to play or observe
-
+	ButtonCustom main_menu_button_list[MAIN_OPTION_COUNT];
 	//-------- color remap info -------//
 
 	ColorRemap	color_remap_array[MAX_COLOR_SCHEME+1];
@@ -165,7 +168,6 @@ private:
 	int			mp_select_session();
 	void			mp_disp_players();
 	int			mp_select_load_option(char *);
-	char *get_bitmap_by_name(const char *bitmap_name);
 	void update_main_menu_button(int x, int y, OptionInfo menu_button, char * bitmap);
 };
 #pragma pack()

--- a/src/OBUTTCUS.cpp
+++ b/src/OBUTTCUS.cpp
@@ -236,6 +236,12 @@ void ButtonCustom::hide()
 }
 //----------- End of function ButtonCustom::hide -------------//
 
+bool ButtonCustom::detect_hover(){
+	if( !init_flag || !enable_flag || pushed_flag || button_wait )
+		return false;
+
+	return mouse.in_area(x1, y1, x2, y2);
+}
 
 //----------- Begin of function ButtonCustom::disp_text_button_func -------------//
 //

--- a/src/OGAMMAIN.cpp
+++ b/src/OGAMMAIN.cpp
@@ -172,15 +172,6 @@ void setup_button_list(int start_x, int start_y,
 		}
 		char value = menu_type + '0';
 		const char values[] = {value, '\0'};
-		// button_param = &values[0];
-		// sprintf(button_param, "%d", menu_type + '0');
-		printf("Are equal? %d\n", strncmp(button_param, values, 2));
-		printf("button_param : %d, 0x%x, relative addr: %d, addr: %p \n", *button_param, *button_param, button_param, button_param);
-		printf("Size of - button_param : %d, relative addr: %d \n", sizeof(*button_param), sizeof(button_param));
-		for(int index = 0; index < sizeof(value); index++)
-		{
-				printf("byte %d - 0x%02hhx\n", index, button_param[index]);
-		}
 		service_button_list[b]
 				.create(currentX, currentY,
 								SWORD_BUTTON_INSTANCES[button_variant_index].width + currentX, SWORD_BUTTON_INSTANCES[button_variant_index].height + currentY,
@@ -232,21 +223,6 @@ static void disp_virtual_button(ButtonCustom *button, int i)
 	pointer = (const char *)button->custom_para.ptr;
 	int menu_type = (*pointer) - '0';
 	err_when(menu_type > 2 || menu_type < 0);
-	// const char (**bitmap_list) = BITMAP_SWORD_VAL;
-	// printf("bitmap_list %d %d \n", sizeof((char**)(button->custom_para).ptr), sizeof(menu_type));
-
-  // printf("menu_type %d 0x%x\n", menu_type, menu_type);
-	// printf("addr button->custom_para.ptr %p\n", button->custom_para.ptr);
-	// printf("* button->custom_para.ptr %d\n", (int *)button->custom_para.ptr);
-	// printf("Size of - menu_type : %d, * button->custom_para.ptr %d\n", sizeof(menu_type), sizeof((int *)button->custom_para.ptr));
-	
-	// for(int index = 0; index < sizeof(menu_type); index++)
-	// {
-	// 		printf("byte %d - 0x%02hhx\n", index, ((char*)button->custom_para.ptr)[index]);
-	// }
-
-
-	// int i_menu = menu_type;
 	const char(**current_bitmap) = BITMAP_SWORD_VAL_C[menu_type];
 
 	// Pushed or highlighted or normal

--- a/src/OGAMMAIN.cpp
+++ b/src/OGAMMAIN.cpp
@@ -122,6 +122,12 @@ static SwordButton SWORD_BUTTON_INSTANCES[SWORD_BUTTON_INSTANCES_SIZE] = {
 		{214, 42, SHORT_SWORD},
 };
 
+/**
+ * @brief Handles the button updates
+ *
+ * @param button Current reference
+ * @param i Additional parameter that could inform that the button is highlighted (2)
+ */
 static void disp_virtual_button(ButtonCustom *button, int i);
 /**
  * @brief Get the bitmap from the name
@@ -256,12 +262,6 @@ void setup_button_list(int start_x, int start_y,
 	}
 }
 
-/**
- * @brief Get the bitmap from the name
- * 
- * @param bitmap_name 
- * @return char* The pointer to the bitmap
- */
 char * get_bitmap_by_name(const char* bitmap_name){
 	char *bitmap = NULL;
 	int resSize;

--- a/src/OGAMMAIN.cpp
+++ b/src/OGAMMAIN.cpp
@@ -579,18 +579,17 @@ void Game::disp_version()
 void Game::single_player_menu()
 {
 	enum { SINGLE_PLAYER_OPTION_COUNT = 5 };
-	static OptionInfo single_player_option_array[SINGLE_PLAYER_OPTION_COUNT];
+	ButtonCustom button_list[SINGLE_PLAYER_OPTION_COUNT];
+	
 #ifndef DISABLE_SINGLE_PLAYER_NEW_GAME
 	ButtonLocation single_player_option_box_array[SINGLE_PLAYER_OPTION_COUNT] = {{6, 10}, {6, 5}, {6, 8}, {6, 8}, {40, 15}};
 	static int single_player_option_button_variant_array[SINGLE_PLAYER_OPTION_COUNT] = {SWORD1, SWORD2, SWORD3, SWORD4, SHORT_SWORD};
-	get_main_menu_button_list(single_player_option_array, SINGLE_PLAYER_OPTION_COUNT, SWORD1_X, SWORD1_Y, single_player_option_button_variant_array, single_player_option_box_array);
-	// {
-	// 	{ 5+SWORD1_X,  10+SWORD1_Y, 282+SWORD1_X,  62+SWORD1_Y },
-	// 	{ 5+SWORD1_X,  67+SWORD1_Y, 282+SWORD1_X, 112+SWORD1_Y },
-	// 	{ 5+SWORD1_X, 120+SWORD1_Y, 282+SWORD1_X, 175+SWORD1_Y },
-	// 	{ 5+SWORD1_X, 182+SWORD1_Y, 282+SWORD1_X, 223+SWORD1_Y },
-	// 	{40+SWORD1_X, 238+SWORD1_Y, 254+SWORD1_X, 280+SWORD1_Y },
-	// };
+	setup_button_list(SWORD1_X, SWORD1_Y,
+										button_list,
+										SINGLE_PLAYER_OPTION_COUNT,
+										single_player_option_box_array,
+										single_player_option_button_variant_array,
+										MENU_TYPE::SINGLEPLAYER);
 
 	static char single_player_option_flag[SINGLE_PLAYER_OPTION_COUNT] =
 	{
@@ -599,14 +598,12 @@ void Game::single_player_menu()
 #else
 	ButtonLocation single_player_option_box_array[SINGLE_PLAYER_OPTION_COUNT] = {{2, 10}, {2, 5}, {2, 3}, {2, -55}, {38, 4}};
 	static int single_player_option_button_variant_array[SINGLE_PLAYER_OPTION_COUNT] = {SWORD1, SWORD2, SWORD3, SWORD4, SHORT_SWORD};
-	get_main_menu_button_list(single_player_option_array, SINGLE_PLAYER_OPTION_COUNT, SWORD1_X, SWORD1_Y, single_player_option_button_variant_array, single_player_option_box_array);
-	// {
-	// 	{ 2+SWORD1_X,  10+SWORD1_Y, 286+SWORD1_X,  65+SWORD1_Y },
-	// 	{ 2+SWORD1_X,  67+SWORD1_Y, 286+SWORD1_X, 109+SWORD1_Y },
-	// 	{ 2+SWORD1_X, 112+SWORD1_Y, 286+SWORD1_X, 171+SWORD1_Y },
-	// 	{ 2+SWORD1_X, 112+SWORD1_Y, 286+SWORD1_X, 171+SWORD1_Y },       // not used
-	// 	{38+SWORD1_X, 174+SWORD1_Y, 256+SWORD1_X, 216+SWORD1_Y },
-	// };
+	setup_button_list(SWORD1_X, SWORD1_Y,
+										button_list,
+										SINGLE_PLAYER_OPTION_COUNT,
+										single_player_option_box_array,
+										single_player_option_button_variant_array,
+										MENU_TYPE::SINGLEPLAYER);
 
 	static char single_player_option_flag[SINGLE_PLAYER_OPTION_COUNT] =
 	{
@@ -623,9 +620,6 @@ void Game::single_player_menu()
 	// sys.blt_virtual_buf();		// blt the virtual front buffer to the screen
 	int refreshFlag = 1, i;
 	mouse_cursor.set_icon(CURSOR_NORMAL);
-	char *menuBitmap = NULL;
-	char *brightBitmap = NULL;
-	char *darkBitmap = NULL;
 	int pointingOption = -1;
 
 
@@ -648,20 +642,12 @@ void Game::single_player_menu()
 
 			vga_util.blt_buf(0,0,VGA_WIDTH-1, VGA_HEIGHT-1);
 
-			if(!menuBitmap)
-				menuBitmap = get_bitmap_by_name(BITMAP_SWORD_SINGLEPLAYER_VAL[BITMAP_SWORD::IDLE]);
-			
-			if(!brightBitmap)
-				brightBitmap = get_bitmap_by_name(BITMAP_SWORD_SINGLEPLAYER_VAL[BITMAP_SWORD::HOVER]);
-				
-			if(!darkBitmap)
-				darkBitmap = get_bitmap_by_name(BITMAP_SWORD_SINGLEPLAYER_VAL[BITMAP_SWORD::ACTIVE]);
-
 			for( i = 0; i < SINGLE_PLAYER_OPTION_COUNT; ++i )
 			{
-				if( single_player_option_flag[i] >= 0)
-					update_main_menu_button(SWORD1_X, SWORD1_Y, single_player_option_array[i], single_player_option_flag[i] ? menuBitmap : darkBitmap);
+				if (button_list[i].enable_flag == 1)
+					button_list[i].paint(0);
 			}
+
 			pointingOption = -1;
 			refreshFlag=0;
 		}
@@ -677,63 +663,19 @@ void Game::single_player_menu()
 		// ###### end Gilbert 18/9 ########//
 
 		// display main menu
-		int newPointingOption = -1;
-		for(i = 0; i < SINGLE_PLAYER_OPTION_COUNT; ++i)
-		{
-			if( single_player_option_flag[i] > 0 &&
-				mouse.in_area(single_player_option_array[i].x1, single_player_option_array[i].y1,
-				single_player_option_array[i].x2, single_player_option_array[i].y2) )
-			{
-				newPointingOption = i;
-				break;
-			}
-		}
-
-		if( pointingOption != newPointingOption)
-		{
-			err_when( !menuBitmap );
-			err_when( !brightBitmap );
-			err_when( !darkBitmap );
-
-			// put un-highlighted option back
-			i = pointingOption;
-			if( i >= 0 && i < SINGLE_PLAYER_OPTION_COUNT )
-				update_main_menu_button(SWORD1_X, SWORD1_Y, single_player_option_array[i], menuBitmap);
-			
-
-			// put new hightlighted option
-			i = newPointingOption;
-			if( i >= 0 && i < SINGLE_PLAYER_OPTION_COUNT )
-				update_main_menu_button(SWORD1_X, SWORD1_Y, single_player_option_array[i], brightBitmap);
-			
-			pointingOption = newPointingOption;
-		}
+		pointingOption = update_hover_button(button_list, SINGLE_PLAYER_OPTION_COUNT, pointingOption);
 
 		sys.blt_virtual_buf();		// blt the virtual front buffer to the screen
 
-		OptionInfo* optionInfo = single_player_option_array;
+		if(!mouse.single_click(0, 0, VGA_WIDTH, VGA_HEIGHT))
+			continue;
 
-		for( int i=0 ; i<SINGLE_PLAYER_OPTION_COUNT ; i++, optionInfo++ )
+		for( int i=0 ; i<SINGLE_PLAYER_OPTION_COUNT ; i++)
 		{
-			if( single_player_option_flag[i] > 0 &&
-				mouse.single_click( optionInfo->x1, optionInfo->y1, optionInfo->x2, optionInfo->y2 ) )
+			if (button_list[i].enable_flag &&
+					button_list[i].pushed_flag == 0 &&
+					button_list[i].detect() == 1)
 			{
-				// free some resource
-				if( menuBitmap )
-				{
-					mem_del(menuBitmap);
-					menuBitmap = NULL;
-				}
-				if( brightBitmap )
-				{
-					mem_del(brightBitmap);
-					brightBitmap = NULL;
-				}
-				if( darkBitmap )
-				{
-					mem_del(darkBitmap);
-					darkBitmap = NULL;
-				}
 
 				refreshFlag = 1;
 
@@ -777,13 +719,6 @@ void Game::single_player_menu()
 			}
 		}
 	}
-
-	if( menuBitmap )
-		mem_del(menuBitmap);
-	if( brightBitmap )
-		mem_del(brightBitmap);
-	if( darkBitmap )
-		mem_del(darkBitmap);
 }
 //------------ End of function Game::single_player_menu -----------//
 


### PR DESCRIPTION
I think this could help to migrate (eventually to a dedicated or more flexible UI definition class/component)

Try to extract main menu buttons definiton
- Use common button (sword ) definition
- Use common function to generate the button list
- Use common function to get the bitmap and use states for the changes
-  Extract button bitmap names to out of scope variables
- Leave original comments for buttons (swords)

The menu looks the same, except for the `else` on  `#ifndef DISABLE_SINGLE_PLAYER_NEW_GAME`