### PR TITLE
Fix text overflow in Spanish translation and some translation improvements

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-05-14 08:14-0500\n"
-"PO-Revision-Date: 2021-10-15 13:54+0200\n"
-"Last-Translator: Lenny Andreu\n"
+"PO-Revision-Date: 2023-05-23 20:54+0200\n"
+"Last-Translator: Jorge Maldonado Ventura\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -58,128 +58,128 @@ msgstr "Cancelar"
 #: src/ODATE.cpp:231 src/ODATE.cpp:235
 #, c-format
 msgid "%s %d, %d"
-msgstr "%2$d de %1$s del %3$d"
+msgstr "%2$d de %1$s, %3$d"
 
 #: src/ODATE.cpp:254
 msgctxt "Month|Full"
 msgid "January"
-msgstr "Enero"
+msgstr "enero"
 
 #: src/ODATE.cpp:256
 msgctxt "Month|Full"
 msgid "February"
-msgstr "Febrero"
+msgstr "febrero"
 
 #: src/ODATE.cpp:258
 msgctxt "Month|Full"
 msgid "March"
-msgstr "Marzo"
+msgstr "marzo"
 
 #: src/ODATE.cpp:260
 msgctxt "Month|Full"
 msgid "April"
-msgstr "Abril"
+msgstr "abril"
 
 #: src/ODATE.cpp:262
 msgctxt "Month|Full"
 msgid "May"
-msgstr "Mayo"
+msgstr "mayo"
 
 #: src/ODATE.cpp:264
 msgctxt "Month|Full"
 msgid "June"
-msgstr "Junio"
+msgstr "junio"
 
 #: src/ODATE.cpp:266
 msgctxt "Month|Full"
 msgid "July"
-msgstr "Julio"
+msgstr "julio"
 
 #: src/ODATE.cpp:268
 msgctxt "Month|Full"
 msgid "August"
-msgstr "Agosto"
+msgstr "agosto"
 
 #: src/ODATE.cpp:270
 msgctxt "Month|Full"
 msgid "September"
-msgstr "Septiembre"
+msgstr "septiembre"
 
 #: src/ODATE.cpp:272
 msgctxt "Month|Full"
 msgid "October"
-msgstr "Octubre"
+msgstr "octubre"
 
 #: src/ODATE.cpp:274
 msgctxt "Month|Full"
 msgid "November"
-msgstr "Noviembre"
+msgstr "noviembre"
 
 #: src/ODATE.cpp:276
 msgctxt "Month|Full"
 msgid "December"
-msgstr "Diciembre"
+msgstr "diciembre"
 
 #. TRANSLATORS: An abbreviated month. If not used in your language, spell full month.
 #: src/ODATE.cpp:295
 msgctxt "Month|Short"
 msgid "Jan"
-msgstr "Ene"
+msgstr "ene"
 
 #: src/ODATE.cpp:297
 msgctxt "Month|Short"
 msgid "Feb"
-msgstr "Feb"
+msgstr "feb"
 
 #: src/ODATE.cpp:299
 msgctxt "Month|Short"
 msgid "Mar"
-msgstr "Mar"
+msgstr "mar"
 
 #: src/ODATE.cpp:301
 msgctxt "Month|Short"
 msgid "Apr"
-msgstr "Abr"
+msgstr "abr"
 
 #: src/ODATE.cpp:303
 msgctxt "Month|Short"
 msgid "May"
-msgstr "Mayo"
+msgstr "mayo"
 
 #: src/ODATE.cpp:305
 msgctxt "Month|Short"
 msgid "Jun"
-msgstr "Jun"
+msgstr "jun"
 
 #: src/ODATE.cpp:307
 msgctxt "Month|Short"
 msgid "Jul"
-msgstr "Jul"
+msgstr "jul"
 
 #: src/ODATE.cpp:309
 msgctxt "Month|Short"
 msgid "Aug"
-msgstr "Ago"
+msgstr "ago"
 
 #: src/ODATE.cpp:311
 msgctxt "Month|Short"
 msgid "Sep"
-msgstr "Sep"
+msgstr "sep"
 
 #: src/ODATE.cpp:313
 msgctxt "Month|Short"
 msgid "Oct"
-msgstr "Oct"
+msgstr "oct"
 
 #: src/ODATE.cpp:315
 msgctxt "Month|Short"
 msgid "Nov"
-msgstr "Nov"
+msgstr "nov"
 
 #: src/ODATE.cpp:317
 msgctxt "Month|Short"
 msgid "Dec"
-msgstr "Dic"
+msgstr "dic"
 
 #. TRANSLATORS: <Town> <Short Firm Name> <Firm #>
 #. This is the name of the firm when there are multiple linked firms to a town.
@@ -226,7 +226,7 @@ msgstr "Combate"
 #: src/OFIRMIF.cpp:696 src/OFIRMIF.cpp:744 src/OR_MIL.cpp:102
 #: src/OR_TECH.cpp:145 src/OR_TRADE.cpp:147 src/OU_MARIF.cpp:524
 msgid "Hit Points"
-msgstr "Puntos de impacto"
+msgstr "Puntos impacto"
 
 #: src/OFIRMIF2.cpp:94 src/OTOWNIF.cpp:1412
 msgid "Spy Skill"
@@ -900,7 +900,7 @@ msgstr "Reputación"
 
 #: src/OGAMEND.cpp:481 src/OR_RANK.cpp:92
 msgid "Fryhtan Battling"
-msgstr "Batallando Frythan"
+msgstr "Matando Frythan"
 
 #: src/OGAMEND.cpp:528 src/OR_RANK.cpp:137
 msgid "Population Score"
@@ -3352,7 +3352,7 @@ msgstr "Permitir atacar"
 
 #: src/OR_NAT.cpp:172 src/OR_NAT.cpp:604
 msgid "Trade Treaty"
-msgstr "Tratado de Comercio"
+msgstr "Tratado comerc."
 
 #: src/OR_NAT.cpp:174
 msgid "Trade Amount"
@@ -3483,31 +3483,31 @@ msgstr "Tiempo total de juego: %s"
 #. TRANSLATORS: Ordinal number for ranking players
 #: src/OR_RANK.cpp:472
 msgid "1st"
-msgstr "1ro"
+msgstr "1.º"
 
 #: src/OR_RANK.cpp:473
 msgid "2nd"
-msgstr "2do"
+msgstr "2.º"
 
 #: src/OR_RANK.cpp:474
 msgid "3rd"
-msgstr "3ro"
+msgstr "3.º"
 
 #: src/OR_RANK.cpp:475
-msgid "4th"
-msgstr "4to"
+msgid "4º"
+msgstr "4.º"
 
 #: src/OR_RANK.cpp:476
 msgid "5th"
-msgstr "5to"
+msgstr "5.º"
 
 #: src/OR_RANK.cpp:477
 msgid "6th"
-msgstr "6to"
+msgstr "6.º"
 
 #: src/OR_RANK.cpp:478
 msgid "7th"
-msgstr "7mo"
+msgstr "7.º"
 
 #: src/OR_SPY.cpp:73
 msgid "Spy Name"
@@ -3571,7 +3571,7 @@ msgstr "Pobladores"
 
 #: src/OR_TOWN.cpp:86 src/OTOWNIF.cpp:295
 msgid "Peasants"
-msgstr "Campesinos"
+msgstr "Campes."
 
 #: src/OR_TOWN.cpp:88
 msgid "Races"
@@ -3583,11 +3583,11 @@ msgstr "Estructura"
 
 #: src/OR_TOWN.cpp:113
 msgid "Unit Cost"
-msgstr "Costo unitario"
+msgstr "Costo unidad"
 
 #: src/OR_TOWN.cpp:117
 msgid "No. of Structures"
-msgstr "Nro. de estructuras"
+msgstr "N. estructuras"
 
 #: src/OR_TOWN.cpp:202
 #, c-format
@@ -5278,7 +5278,7 @@ msgstr "Resistencia"
 
 #: src/OTOWNIF.cpp:322
 msgid "Avg"
-msgstr "Promedio"
+msgstr "Prom."
 
 #: src/OTOWNIF.cpp:356
 msgid "Controlled by Rebels"


### PR DESCRIPTION
There were many issues with overflowing text (text was usually too long) in the Spanish translation, so I fixed some of them. However, I don't know the code, so I ask if you can solve the following ones:

![Captura de pantalla de 2023-05-23 20-41-47](https://github.com/the3dfxdude/7kaa/assets/14212780/98832bda-cfb5-4107-be00-52a7c2c85daf)
![Captura de pantalla de 2023-05-23 20-33-16](https://github.com/the3dfxdude/7kaa/assets/14212780/6fa696c1-01e4-4ee4-8bb1-b5ef7cbc8adf)

I've also corrected ordinals (following Fundéu's recommendations ["*En español no se recomienda emplear las formas 1ro, 2do, 3ro, 4to…, que son un calco de las usadas en inglés*"](https://www.fundeu.es/recomendacion/numero-ordinales-claves-de-escritura/)) and months names (in Spanish they are lower-case).