### PR TITLE
LocaleRes: fix build with NLS disabled

### DIFF
--- a/src/LocaleRes.cpp
+++ b/src/LocaleRes.cpp
@@ -22,9 +22,9 @@
 //Description : Locale Resources
 
 #include <stdlib.h>
+#include <locale.h>
 #ifdef ENABLE_NLS
 #include <libintl.h>
-#include <locale.h>
 #endif
 
 #include <ALL.h>


### PR DESCRIPTION
Include `locale.h` unconditionally, as `LC_MESSAGES` constant from it is used in `get_messages_locale()` regardless of `ENABLE_NLS`. Not sure if that's correct logic there, alternative fix would be to warp `LC_MESSAGES` usage in `get_messages_locale` in `#ifdef ENABLE_NLS` too.